### PR TITLE
ci: add lint workflow (yamllint, shellcheck, helm lint, gitleaks)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,84 @@
+---
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    name: YAML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yaml .
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck on all shell scripts
+        run: |
+          shopt -s globstar nullglob
+          files=$(find . -name '*.sh' -type f)
+          if [ -n "$files" ]; then
+            echo "$files" | xargs shellcheck --severity=warning
+          else
+            echo "No shell scripts found, skipping."
+          fi
+
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Run Helm lint on charts
+        run: |
+          charts=$(find . -name 'Chart.yaml' -exec dirname {} \;)
+          if [ -n "$charts" ]; then
+            echo "$charts" | while read -r chart; do
+              echo "Linting $chart..."
+              helm lint "$chart"
+            done
+          else
+            echo "No Helm charts found, skipping."
+          fi
+
+  gitleaks:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/lint.yaml` triggered on push and PR to `main`/`develop`
- 4 parallel jobs: yamllint, shellcheck, helm lint (conditional), gitleaks secret scanning
- Helm lint and shellcheck gracefully skip when no matching files exist

## Test plan
- [ ] Verify workflow triggers on PR to develop
- [ ] Verify yamllint job runs against `.yamllint.yaml` config
- [ ] Verify shellcheck and helm lint skip gracefully with no matching files
- [ ] Verify gitleaks scans full history

Closes #5