### PR TITLE
feat(operator): deploy Percona Server for MongoDB Operator with Kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ SHELL := /usr/bin/env bash
 # ──────────────────────────────────────────────
 KIND_CLUSTER_NAME ?= mongodb-dbaas
 KUBECONFIG ?= $(HOME)/.kube/config
+OPERATOR_NAMESPACE ?= mongodb-operator
+HELM_REPO_NAME ?= percona
+HELM_REPO_URL ?= https://percona.github.io/percona-helm-charts/
 
 # ──────────────────────────────────────────────
 # Help
@@ -59,7 +62,17 @@ teardown: ## Destroy kind cluster and clean up
 # ──────────────────────────────────────────────
 .PHONY: deploy-operator
 deploy-operator: ## Install Percona Operator for MongoDB
-	@echo "TODO: implement in Phase 2"
+	@echo "Deploying Percona Operator for MongoDB..."
+	@kubectl apply -k operator/
+	@helm repo add $(HELM_REPO_NAME) $(HELM_REPO_URL) 2>/dev/null || true
+	@helm repo update $(HELM_REPO_NAME)
+	@helm upgrade --install psmdb-operator-crds $(HELM_REPO_NAME)/psmdb-operator-crds \
+		--namespace $(OPERATOR_NAMESPACE)
+	@helm upgrade --install psmdb-operator $(HELM_REPO_NAME)/psmdb-operator \
+		--namespace $(OPERATOR_NAMESPACE) \
+		-f operator/percona-server-mongodb-operator/values.yaml \
+		--wait --timeout 120s
+	@echo "Percona Operator deployed successfully."
 
 .PHONY: deploy-replicaset
 deploy-replicaset: ## Deploy 3-node replica set

--- a/operator/kustomization.yaml
+++ b/operator/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mongodb-operator
+
+resources:
+  - namespace.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: mongodb-dbaas-platform
+  app.kubernetes.io/managed-by: kustomize
+
+# The Percona Operator is deployed via Helm (see Makefile deploy-operator target).
+# This kustomization manages the namespace and any additional resources
+# that are not part of the Helm chart (e.g., custom RBAC, NetworkPolicies).
+#
+# Helm install command:
+#   helm repo add percona https://percona.github.io/percona-helm-charts/
+#   helm install psmdb-operator-crds percona/psmdb-operator-crds \
+#     --namespace mongodb-operator
+#   helm install psmdb-operator percona/psmdb-operator \
+#     --namespace mongodb-operator \
+#     -f operator/percona-server-mongodb-operator/values.yaml

--- a/operator/namespace.yaml
+++ b/operator/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mongodb-operator
+  labels:
+    app.kubernetes.io/name: percona-server-mongodb-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: "Namespace for the Percona Server for MongoDB Operator"

--- a/operator/percona-server-mongodb-operator/values.yaml
+++ b/operator/percona-server-mongodb-operator/values.yaml
@@ -1,0 +1,54 @@
+---
+# Percona Server for MongoDB Operator - Helm Values
+# Chart: percona/psmdb-operator
+# Version: 1.22.0
+#
+# Repository: https://percona.github.io/percona-helm-charts/
+# Docs: https://docs.percona.com/percona-operator-for-mongodb/
+
+# Operator replica count (1 is sufficient for most deployments)
+replicaCount: 1
+
+# Operator container resources
+resources:
+  limits:
+    cpu: 250m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Watch cluster-wide or single namespace
+# Set to "" for cluster-wide, or a specific namespace
+watchNamespace: ""
+
+# Enable RBAC creation
+rbac:
+  create: true
+
+# Service account
+serviceAccount:
+  create: true
+
+# Operator log level (INFO, DEBUG, ERROR)
+logLevel: INFO
+
+# Disable telemetry
+disableTelemetry: true
+
+# Pod scheduling
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+
+# Container security context
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
## Summary
- Add `operator/namespace.yaml` with proper `app.kubernetes.io/*` labels
- Add `operator/percona-server-mongodb-operator/values.yaml` with production-ready defaults (security-hardened, telemetry off)
- Add `operator/kustomization.yaml` managing namespace and documenting Helm install flow
- Update `Makefile` `deploy-operator` target with Helm install for CRDs + operator chart

## Test plan
- [ ] Verify `kubectl apply -k operator/` creates the namespace
- [ ] Verify `make deploy-operator` installs CRDs and operator on a running cluster
- [ ] Verify operator pod starts with security context applied

Closes #7