### PR TITLE
feat(storage): add tuned StorageClass with WaitForFirstConsumer

### DIFF
--- a/clusters/replicaset/storage-class.yaml
+++ b/clusters/replicaset/storage-class.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mongodb-replicaset-storage
+  labels:
+    app.kubernetes.io/name: mongodb-storage
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      StorageClass optimized for MongoDB replica set workloads.
+      Uses WaitForFirstConsumer to ensure data locality and
+      Retain policy for defense-in-depth data protection.
+    storageclass.kubernetes.io/is-default-class: "false"
+# For kind/local development: rancher.io/local-path
+# For AWS EKS: ebs.csi.aws.com
+# For Azure AKS: disk.csi.azure.com
+# For GCP GKE: pd.csi.storage.gke.io
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+allowVolumeExpansion: true

--- a/clusters/sharded/storage-class.yaml
+++ b/clusters/sharded/storage-class.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mongodb-sharded-storage
+  labels:
+    app.kubernetes.io/name: mongodb-storage
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      StorageClass optimized for MongoDB sharded cluster workloads.
+      Shared by config servers, shard replica sets, and mongos instances.
+      Uses WaitForFirstConsumer to ensure data locality and
+      Retain policy for defense-in-depth data protection.
+    storageclass.kubernetes.io/is-default-class: "false"
+# For kind/local development: rancher.io/local-path
+# For AWS EKS: ebs.csi.aws.com
+# For Azure AKS: disk.csi.azure.com
+# For GCP GKE: pd.csi.storage.gke.io
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+allowVolumeExpansion: true


### PR DESCRIPTION
## Summary
- Add `clusters/replicaset/storage-class.yaml` for replica set workloads
- Add `clusters/sharded/storage-class.yaml` for sharded cluster workloads
- Both use `WaitForFirstConsumer` binding, `Retain` reclaim, volume expansion enabled
- Documented provisioner comments for cloud CSI drivers (EBS, Azure Disk, GCE PD)

## Test plan
- [ ] Verify StorageClass manifests apply cleanly on a kind cluster
- [ ] Verify `WaitForFirstConsumer` binding mode is set
- [ ] Verify labels follow `app.kubernetes.io/*` conventions

Closes #8