### PR TITLE
feat(replicaset): deploy 3-node replica set with Percona CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,14 @@ deploy-operator: ## Install Percona Operator for MongoDB
 
 .PHONY: deploy-replicaset
 deploy-replicaset: ## Deploy 3-node replica set
-	@echo "TODO: implement in Phase 2"
+	@echo "Deploying 3-node MongoDB replica set..."
+	@kubectl create namespace mongodb --dry-run=client -o yaml | kubectl apply -f -
+	@kubectl apply -k clusters/replicaset/
+	@echo "Waiting for replica set to become ready..."
+	@kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=mongod \
+		-n mongodb --timeout=300s 2>/dev/null || \
+		echo "Timeout waiting for pods (may still be initializing)."
+	@echo "Replica set deployment initiated."
 
 .PHONY: deploy-sharded
 deploy-sharded: ## Deploy sharded cluster

--- a/clusters/replicaset/cr-replicaset.yaml
+++ b/clusters/replicaset/cr-replicaset.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: mongodb-rs
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-rs
+    app.kubernetes.io/component: replicaset
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: percona-operator
+  annotations:
+    description: "3-node MongoDB replica set for production workloads"
+spec:
+  crVersion: 1.22.0
+  image: percona/percona-server-mongodb:7.0.14-8
+  imagePullPolicy: IfNotPresent
+
+  # MongoDB users managed via Kubernetes Secrets
+  secrets:
+    users: mongodb-rs-secrets
+
+  # Replica set configuration
+  replsets:
+    - name: rs0
+      size: 3
+      # Pod affinity: spread across nodes for HA
+      affinity:
+        antiAffinityTopologyKey: kubernetes.io/hostname
+      # Pod disruption budget: at most 1 pod unavailable
+      podDisruptionBudget:
+        maxUnavailable: 1
+      # Resource limits and requests
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+      # Persistent storage configuration
+      volumeSpec:
+        persistentVolumeClaim:
+          storageClassName: mongodb-replicaset-storage
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+      # Non-voting members (none for standard 3-node RS)
+      nonvoting:
+        enabled: false
+      # Arbiter (disabled - using 3 full data-bearing members)
+      arbiter:
+        enabled: false
+
+  # MongoDB configuration
+  mongod:
+    # WiredTiger cache size (default: 50% of memory limit - 1GB)
+    storage:
+      wiredTiger:
+        engineConfig:
+          cacheSizeRatio: 0.5
+    # Network configuration
+    net:
+      port: 27017
+    # Operation profiling (log slow queries > 100ms)
+    operationProfiling:
+      mode: slowOp
+      slowOpThresholdMs: 100
+
+  # Backup configuration (managed separately in Phase 3)
+  backup:
+    enabled: false
+
+  # PMM monitoring integration (managed separately in Phase 5)
+  pmm:
+    enabled: false
+
+  # Update strategy
+  updateStrategy: SmartUpdate

--- a/clusters/replicaset/kustomization.yaml
+++ b/clusters/replicaset/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - storage-class.yaml
+  - cr-replicaset.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: mongodb-dbaas-platform
+  app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
## Summary
- Add `clusters/replicaset/cr-replicaset.yaml` with 3-member replica set (anti-affinity, PDB, resource limits, 20Gi storage)
- Add `clusters/replicaset/kustomization.yaml` combining StorageClass and CR
- Update Makefile `deploy-replicaset` target with namespace creation and kustomize apply

## Test plan
- [ ] Verify CR applies cleanly with the Percona Operator running
- [ ] Verify 3 pods come up with correct labels
- [ ] Verify anti-affinity spreads pods across nodes
- [ ] Verify WiredTiger cache and slow query profiling settings

Closes #10