### PR TITLE
feat(sharding): deploy sharded cluster (mongos + config servers + 2 shards)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,14 @@ deploy-replicaset: ## Deploy 3-node replica set
 
 .PHONY: deploy-sharded
 deploy-sharded: ## Deploy sharded cluster
-	@echo "TODO: implement in Phase 2"
+	@echo "Deploying sharded MongoDB cluster..."
+	@kubectl create namespace mongodb-sharded --dry-run=client -o yaml | kubectl apply -f -
+	@kubectl apply -k clusters/sharded/
+	@echo "Waiting for sharded cluster to become ready..."
+	@kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=mongos \
+		-n mongodb-sharded --timeout=300s 2>/dev/null || \
+		echo "Timeout waiting for mongos pods (may still be initializing)."
+	@echo "Sharded cluster deployment initiated."
 
 .PHONY: deploy-self-service
 deploy-self-service: ## Install Crossplane + XRDs + Compositions

--- a/clusters/sharded/cr-sharded.yaml
+++ b/clusters/sharded/cr-sharded.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: mongodb-sharded
+  namespace: mongodb-sharded
+  labels:
+    app.kubernetes.io/name: mongodb-sharded
+    app.kubernetes.io/component: sharded-cluster
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: percona-operator
+  annotations:
+    description: >-
+      Sharded MongoDB cluster with 2 shards, 3 config servers,
+      and 3 mongos routers for horizontal scaling workloads.
+spec:
+  crVersion: 1.22.0
+  image: percona/percona-server-mongodb:7.0.14-8
+  imagePullPolicy: IfNotPresent
+
+  # MongoDB users managed via Kubernetes Secrets
+  secrets:
+    users: mongodb-sharded-secrets
+
+  # Sharding configuration
+  sharding:
+    enabled: true
+
+    # Config server replica set
+    configsvrReplSet:
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: kubernetes.io/hostname
+      podDisruptionBudget:
+        maxUnavailable: 1
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "250m"
+          memory: 512Mi
+      volumeSpec:
+        persistentVolumeClaim:
+          storageClassName: mongodb-sharded-storage
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
+
+    # Mongos router configuration
+    mongos:
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: kubernetes.io/hostname
+      podDisruptionBudget:
+        maxUnavailable: 1
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "250m"
+          memory: 512Mi
+      expose:
+        exposeType: ClusterIP
+
+  # Shard replica sets
+  replsets:
+    # Shard 0
+    - name: shard0
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: kubernetes.io/hostname
+      podDisruptionBudget:
+        maxUnavailable: 1
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+      volumeSpec:
+        persistentVolumeClaim:
+          storageClassName: mongodb-sharded-storage
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+
+    # Shard 1
+    - name: shard1
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: kubernetes.io/hostname
+      podDisruptionBudget:
+        maxUnavailable: 1
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4Gi
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+      volumeSpec:
+        persistentVolumeClaim:
+          storageClassName: mongodb-sharded-storage
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+
+  # MongoDB configuration
+  mongod:
+    storage:
+      wiredTiger:
+        engineConfig:
+          cacheSizeRatio: 0.5
+    net:
+      port: 27017
+    operationProfiling:
+      mode: slowOp
+      slowOpThresholdMs: 100
+
+  # Backup configuration (managed separately in Phase 3)
+  backup:
+    enabled: false
+
+  # PMM monitoring integration (managed separately in Phase 5)
+  pmm:
+    enabled: false
+
+  # Update strategy
+  updateStrategy: SmartUpdate

--- a/clusters/sharded/kustomization.yaml
+++ b/clusters/sharded/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - storage-class.yaml
+  - cr-sharded.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: mongodb-dbaas-platform
+  app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
## Summary
- Add `clusters/sharded/cr-sharded.yaml` with full sharded topology (3 mongos, 3 config servers, 2x3 shards)
- Add `clusters/sharded/kustomization.yaml` combining StorageClass and CR
- Update Makefile `deploy-sharded` target

## Test plan
- [ ] Verify CR applies cleanly with the Percona Operator
- [ ] Verify mongos, config server, and shard pods come up
- [ ] Verify `sh.status()` shows 2 registered shards

Closes #11