### PR TITLE
feat(security): configure TLS with cert-manager for intra-cluster and client connections

### DIFF
--- a/security/tls/certificate.yaml
+++ b/security/tls/certificate.yaml
@@ -1,0 +1,99 @@
+---
+# TLS certificate for MongoDB replica set members (intra-cluster communication)
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mongodb-rs-tls
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-rs-tls
+    app.kubernetes.io/component: tls
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: cert-manager
+  annotations:
+    description: >-
+      TLS certificate for MongoDB replica set members. Used for
+      intra-cluster encryption (member-to-member) and client connections.
+spec:
+  secretName: mongodb-rs-tls-secret
+  duration: 8760h  # 1 year
+  renewBefore: 720h  # 30 days before expiry
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    # Replica set member hostnames
+    - "mongodb-rs-rs0-0.mongodb-rs-rs0.mongodb.svc.cluster.local"
+    - "mongodb-rs-rs0-1.mongodb-rs-rs0.mongodb.svc.cluster.local"
+    - "mongodb-rs-rs0-2.mongodb-rs-rs0.mongodb.svc.cluster.local"
+    # Service DNS names
+    - "mongodb-rs-rs0.mongodb.svc.cluster.local"
+    - "mongodb-rs.mongodb.svc.cluster.local"
+    # Wildcard for dynamic member discovery
+    - "*.mongodb-rs-rs0.mongodb.svc.cluster.local"
+    - "*.mongodb.svc.cluster.local"
+    # Short names for internal access
+    - "mongodb-rs-rs0"
+    - "mongodb-rs"
+    - "localhost"
+  ipAddresses:
+    - "127.0.0.1"
+  issuerRef:
+    name: mongodb-tls-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# TLS certificate for MongoDB sharded cluster
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mongodb-sharded-tls
+  namespace: mongodb-sharded
+  labels:
+    app.kubernetes.io/name: mongodb-sharded-tls
+    app.kubernetes.io/component: tls
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: cert-manager
+  annotations:
+    description: >-
+      TLS certificate for MongoDB sharded cluster components:
+      mongos routers, config servers, and shard replica sets.
+spec:
+  secretName: mongodb-sharded-tls-secret
+  duration: 8760h
+  renewBefore: 720h
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    # Mongos
+    - "*.mongodb-sharded-mongos.mongodb-sharded.svc.cluster.local"
+    - "mongodb-sharded-mongos.mongodb-sharded.svc.cluster.local"
+    # Config servers
+    - "*.mongodb-sharded-cfg.mongodb-sharded.svc.cluster.local"
+    - "mongodb-sharded-cfg.mongodb-sharded.svc.cluster.local"
+    # Shard 0
+    - "*.mongodb-sharded-shard0.mongodb-sharded.svc.cluster.local"
+    - "mongodb-sharded-shard0.mongodb-sharded.svc.cluster.local"
+    # Shard 1
+    - "*.mongodb-sharded-shard1.mongodb-sharded.svc.cluster.local"
+    - "mongodb-sharded-shard1.mongodb-sharded.svc.cluster.local"
+    # Cluster-level DNS
+    - "*.mongodb-sharded.svc.cluster.local"
+    - "localhost"
+  ipAddresses:
+    - "127.0.0.1"
+  issuerRef:
+    name: mongodb-tls-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/security/tls/issuer.yaml
+++ b/security/tls/issuer.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: mongodb-ca-issuer
+  labels:
+    app.kubernetes.io/name: mongodb-ca-issuer
+    app.kubernetes.io/component: tls
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: cert-manager
+  annotations:
+    description: >-
+      Self-signed CA ClusterIssuer for MongoDB TLS certificates.
+      In production, replace with a proper CA (Vault PKI, ACME, or
+      an organization-managed intermediate CA).
+spec:
+  selfSigned: {}
+---
+# CA Certificate used to sign MongoDB server and client certificates
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mongodb-ca
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: mongodb-ca
+    app.kubernetes.io/component: tls
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: cert-manager
+spec:
+  isCA: true
+  commonName: mongodb-dbaas-ca
+  duration: 87600h  # 10 years
+  renewBefore: 8760h  # 1 year before expiry
+  secretName: mongodb-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: mongodb-ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# Issuer that uses the CA certificate to sign server/client certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: mongodb-tls-issuer
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-tls-issuer
+    app.kubernetes.io/component: tls
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: cert-manager
+spec:
+  ca:
+    secretName: mongodb-ca-secret

--- a/security/tls/tls-config.md
+++ b/security/tls/tls-config.md
@@ -1,0 +1,69 @@
+# 🔒 TLS Configuration for MongoDB
+
+## 📌 Overview
+
+All MongoDB communications are encrypted using TLS 1.2+ certificates managed by [cert-manager](https://cert-manager.io/). This covers:
+
+- **Intra-cluster**: Member-to-member replication traffic within replica sets
+- **Client connections**: Application-to-MongoDB connections via mongos or direct to replica set
+- **Sharded cluster**: All traffic between mongos, config servers, and shard replica sets
+
+## 🏗️ Certificate Architecture
+
+```
+ClusterIssuer (self-signed)
+    |
+    v
+CA Certificate (mongodb-ca, 10y validity)
+    |
+    v
+Issuer (mongodb-tls-issuer, per namespace)
+    |
+    +-- Certificate: mongodb-rs-tls (replica set)
+    +-- Certificate: mongodb-sharded-tls (sharded cluster)
+```
+
+### Certificate Details
+
+| Certificate | Namespace | Validity | Renewal | Secret |
+|-------------|-----------|----------|---------|--------|
+| `mongodb-ca` | cert-manager | 10 years | 1 year before expiry | `mongodb-ca-secret` |
+| `mongodb-rs-tls` | mongodb | 1 year | 30 days before expiry | `mongodb-rs-tls-secret` |
+| `mongodb-sharded-tls` | mongodb-sharded | 1 year | 30 days before expiry | `mongodb-sharded-tls-secret` |
+
+### Key Specifications
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| CA algorithm | ECDSA P-256 | Smaller key size, faster TLS handshake |
+| Server/client algorithm | RSA 2048 | Broad compatibility with MongoDB drivers |
+| Key encoding | PKCS8 | Required by Percona Operator |
+| Usages | server auth, client auth | Mutual TLS between members |
+
+## 🔧 Integration with Percona Operator
+
+The Percona Operator references TLS secrets in the PerconaServerMongoDB CR:
+
+```yaml
+spec:
+  secrets:
+    ssl: mongodb-rs-tls-secret        # Server certificate
+    sslInternal: mongodb-rs-tls-secret # Internal member certificate
+```
+
+> **Note**: The `ssl` and `sslInternal` secrets must contain `tls.crt`, `tls.key`, and `ca.crt` keys. cert-manager populates these automatically.
+
+## ⚠️ Production Considerations
+
+1. **Replace the self-signed CA** with an organization-managed CA or Vault PKI backend for production deployments
+2. **Monitor certificate expiry** using the Prometheus cert-manager exporter (`cert_manager_certificate_expiration_timestamp_seconds`)
+3. **Test certificate rotation** before deploying to production - cert-manager handles renewal automatically, but the Percona Operator must be configured to detect and reload certificates
+4. **Client certificates**: For applications requiring mTLS, issue additional certificates from the same CA using cert-manager
+
+## 📋 Deployment Order
+
+1. Install cert-manager (prerequisite)
+2. Apply `issuer.yaml` (ClusterIssuer + CA Certificate + Namespace Issuer)
+3. Apply `certificate.yaml` (server/client certificates)
+4. Update Percona CR to reference TLS secrets
+5. Verify with: `kubectl get certificates -A`


### PR DESCRIPTION
## Summary
- Add `security/tls/issuer.yaml` with ClusterIssuer, CA Certificate, and namespace Issuer
- Add `security/tls/certificate.yaml` with TLS certs for replica set and sharded cluster
- Add `security/tls/tls-config.md` with architecture docs, deployment order, and production notes

## Test plan
- [ ] Verify cert-manager CRs apply cleanly with cert-manager installed
- [ ] Verify certificates are issued and secrets populated
- [ ] Verify DNS names cover all member pod hostnames

Closes #16