### PR TITLE
feat(security): enable SCRAM-SHA-256 authentication and audit logging

### DIFF
--- a/security/audit/audit-config.yaml
+++ b/security/audit/audit-config.yaml
@@ -1,0 +1,140 @@
+---
+# MongoDB audit log configuration for the Percona Operator.
+# Applied as a ConfigMap and referenced in the PerconaServerMongoDB CR.
+#
+# Audit logging captures:
+#   - Authentication events (login success/failure)
+#   - Authorization events (privilege checks)
+#   - CRUD operations on sensitive collections
+#   - DDL operations (create/drop database, collection, index)
+#   - Role and user management operations
+#
+# Reference: https://www.mongodb.com/docs/manual/core/auditing/
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-audit-config
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-audit-config
+    app.kubernetes.io/component: audit
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      Audit log filter configuration for MongoDB. Captures authentication,
+      authorization, DDL, and user management events for compliance.
+data:
+  mongod.conf: |
+    auditLog:
+      destination: file
+      format: JSON
+      path: /var/log/mongodb/audit.json
+      filter: >-
+        {
+          "$or": [
+            {
+              "atype": {
+                "$in": [
+                  "authenticate",
+                  "authCheck",
+                  "createUser",
+                  "dropUser",
+                  "updateUser",
+                  "grantRolesToUser",
+                  "revokeRolesFromUser",
+                  "createRole",
+                  "dropRole",
+                  "updateRole",
+                  "createDatabase",
+                  "dropDatabase",
+                  "createCollection",
+                  "dropCollection",
+                  "createIndex",
+                  "dropIndex",
+                  "shutdown",
+                  "replSetReconfig",
+                  "applicationMessage"
+                ]
+              }
+            },
+            {
+              "atype": "authCheck",
+              "param.command": {
+                "$in": [
+                  "delete",
+                  "update",
+                  "drop",
+                  "dropDatabase",
+                  "killCursors",
+                  "killOp"
+                ]
+              }
+            }
+          ]
+        }
+---
+# Audit config for sharded cluster namespace
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-audit-config
+  namespace: mongodb-sharded
+  labels:
+    app.kubernetes.io/name: mongodb-audit-config
+    app.kubernetes.io/component: audit
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      Audit log filter configuration for MongoDB sharded cluster.
+data:
+  mongod.conf: |
+    auditLog:
+      destination: file
+      format: JSON
+      path: /var/log/mongodb/audit.json
+      filter: >-
+        {
+          "$or": [
+            {
+              "atype": {
+                "$in": [
+                  "authenticate",
+                  "authCheck",
+                  "createUser",
+                  "dropUser",
+                  "updateUser",
+                  "grantRolesToUser",
+                  "revokeRolesFromUser",
+                  "createRole",
+                  "dropRole",
+                  "updateRole",
+                  "createDatabase",
+                  "dropDatabase",
+                  "createCollection",
+                  "dropCollection",
+                  "createIndex",
+                  "dropIndex",
+                  "shutdown",
+                  "replSetReconfig",
+                  "applicationMessage"
+                ]
+              }
+            },
+            {
+              "atype": "authCheck",
+              "param.command": {
+                "$in": [
+                  "delete",
+                  "update",
+                  "drop",
+                  "dropDatabase",
+                  "killCursors",
+                  "killOp"
+                ]
+              }
+            }
+          ]
+        }

--- a/security/auth/scram-users.yaml
+++ b/security/auth/scram-users.yaml
@@ -1,0 +1,73 @@
+---
+# MongoDB user credentials managed as Kubernetes Secrets.
+# The Percona Operator reads these secrets to configure SCRAM-SHA-256
+# authentication for the MongoDB cluster.
+#
+# IMPORTANT: This file defines the Secret structure with placeholder values.
+# Actual passwords MUST be injected at deployment time via:
+#   - kubectl create secret (imperatively)
+#   - External Secrets Operator
+#   - Vault Agent Injector
+#   - Sealed Secrets
+#
+# Never store real credentials in this file or in version control.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-rs-secrets
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-rs-secrets
+    app.kubernetes.io/component: auth
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      SCRAM-SHA-256 credentials for the MongoDB replica set.
+      Passwords are base64-encoded placeholders - replace before deployment.
+type: Opaque
+stringData:
+  # Database admin user (full cluster management)
+  MONGODB_DATABASE_ADMIN_USER: "databaseAdmin"
+  MONGODB_DATABASE_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  # Cluster admin user (replica set operations)
+  MONGODB_CLUSTER_ADMIN_USER: "clusterAdmin"
+  MONGODB_CLUSTER_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  # User admin (user/role management)
+  MONGODB_USER_ADMIN_USER: "userAdmin"
+  MONGODB_USER_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  # Cluster monitor user (monitoring read-only)
+  MONGODB_CLUSTER_MONITOR_USER: "clusterMonitor"
+  MONGODB_CLUSTER_MONITOR_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  # Backup user (PBM operations)
+  MONGODB_BACKUP_USER: "backup"
+  MONGODB_BACKUP_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+---
+# Sharded cluster credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-sharded-secrets
+  namespace: mongodb-sharded
+  labels:
+    app.kubernetes.io/name: mongodb-sharded-secrets
+    app.kubernetes.io/component: auth
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    description: >-
+      SCRAM-SHA-256 credentials for the MongoDB sharded cluster.
+      Passwords are base64-encoded placeholders - replace before deployment.
+type: Opaque
+stringData:
+  MONGODB_DATABASE_ADMIN_USER: "databaseAdmin"
+  MONGODB_DATABASE_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  MONGODB_CLUSTER_ADMIN_USER: "clusterAdmin"
+  MONGODB_CLUSTER_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  MONGODB_USER_ADMIN_USER: "userAdmin"
+  MONGODB_USER_ADMIN_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  MONGODB_CLUSTER_MONITOR_USER: "clusterMonitor"
+  MONGODB_CLUSTER_MONITOR_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"
+  MONGODB_BACKUP_USER: "backup"
+  MONGODB_BACKUP_PASSWORD: "REPLACE_WITH_SECURE_PASSWORD"


### PR DESCRIPTION
## Summary
- Add `security/auth/scram-users.yaml` with SCRAM-SHA-256 user secrets (placeholder passwords) for RS and sharded cluster
- Add `security/audit/audit-config.yaml` with JSON audit log filters for auth, DDL, and destructive operations
- 5 user roles: databaseAdmin, clusterAdmin, userAdmin, clusterMonitor, backup

## Test plan
- [ ] Verify secrets apply cleanly
- [ ] Verify no plaintext passwords in manifests (only placeholders)
- [ ] Verify audit filter syntax is valid JSON

Closes #17