### PR TITLE
feat(backup): add restore scripts (full + PITR) with integrity validation

### DIFF
--- a/backup/restore/restore-full.sh
+++ b/backup/restore/restore-full.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# restore-full.sh - Restore MongoDB from the latest full snapshot
+#
+# Usage:
+#   ./backup/restore/restore-full.sh [OPTIONS]
+#
+# Options:
+#   --help              Show this help message
+#   --dry-run           Print commands without executing
+#   --backup-name NAME  Specify backup name (default: latest)
+#   --namespace NS      MongoDB namespace (default: mongodb)
+#   --cluster NAME      Cluster name (default: mongodb-rs)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
+BACKUP_NAME=""
+DRY_RUN=false
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+run() {
+  if [ "${DRY_RUN}" = true ]; then
+    log "[DRY-RUN] $*"
+  else
+    log "Running: $*"
+    "$@"
+  fi
+}
+
+usage() {
+  grep '^#' "${BASH_SOURCE[0]}" | grep -v '!/usr/bin' | sed 's/^# \?//'
+  exit 0
+}
+
+# ──────────────────────────────────────────────
+# Argument parsing
+# ──────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help) usage ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --backup-name) BACKUP_NAME="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+    *) log "ERROR: Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+# ──────────────────────────────────────────────
+# Precondition checks
+# ──────────────────────────────────────────────
+
+check_prerequisites() {
+  local missing=()
+  for cmd in kubectl jq; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    log "ERROR: Missing required tools: ${missing[*]}"
+    exit 3
+  fi
+
+  # Verify cluster exists
+  if ! kubectl get psmdb "${CLUSTER_NAME}" -n "${NAMESPACE}" &>/dev/null; then
+    log "ERROR: PerconaServerMongoDB '${CLUSTER_NAME}' not found in namespace '${NAMESPACE}'"
+    exit 3
+  fi
+}
+
+# ──────────────────────────────────────────────
+# Get latest backup name
+# ──────────────────────────────────────────────
+
+get_latest_backup() {
+  if [ -n "${BACKUP_NAME}" ]; then
+    log "Using specified backup: ${BACKUP_NAME}"
+    return 0
+  fi
+
+  log "Finding latest completed backup..."
+  BACKUP_NAME=$(kubectl get psmdb-backup -n "${NAMESPACE}" \
+    -o json | jq -r '.items |
+      map(select(.status.state == "ready")) |
+      sort_by(.status.completed) |
+      last |
+      .metadata.name // empty')
+
+  if [ -z "${BACKUP_NAME}" ]; then
+    log "ERROR: No completed backups found in namespace '${NAMESPACE}'"
+    exit 1
+  fi
+
+  log "Latest backup: ${BACKUP_NAME}"
+}
+
+# ──────────────────────────────────────────────
+# Restore
+# ──────────────────────────────────────────────
+
+perform_restore() {
+  log "Starting full restore from backup '${BACKUP_NAME}'..."
+
+  # Create restore CR
+  local restore_name="restore-$(date +%Y%m%d-%H%M%S)"
+
+  run kubectl apply -f - <<EOF
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDBRestore
+metadata:
+  name: ${restore_name}
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  backupName: ${BACKUP_NAME}
+EOF
+
+  log "Restore CR '${restore_name}' created."
+  log "Waiting for restore to complete..."
+
+  run kubectl wait --for=jsonpath='{.status.state}'=ready \
+    "psmdb-restore/${restore_name}" \
+    -n "${NAMESPACE}" \
+    --timeout=600s
+
+  log "Restore completed successfully."
+}
+
+# ──────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────
+
+validate_restore() {
+  log "Running post-restore validation..."
+  run bash "${SCRIPT_DIR}/validate-integrity.sh" \
+    --namespace "${NAMESPACE}" \
+    --cluster "${CLUSTER_NAME}"
+  log "Validation complete."
+}
+
+# ──────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────
+
+main() {
+  log "=== MongoDB Full Restore ==="
+
+  check_prerequisites
+  get_latest_backup
+  perform_restore
+  validate_restore
+
+  log "=== Full restore completed successfully ==="
+}
+
+main

--- a/backup/restore/restore-pitr.sh
+++ b/backup/restore/restore-pitr.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# restore-pitr.sh - Point-in-Time Recovery for MongoDB
+#
+# Usage:
+#   ./backup/restore/restore-pitr.sh [OPTIONS]
+#
+# Options:
+#   --help              Show this help message
+#   --dry-run           Print commands without executing
+#   --target-time TIME  Target restore time in ISO 8601 format (required)
+#                       Example: 2024-01-15T14:30:00Z
+#   --namespace NS      MongoDB namespace (default: mongodb)
+#   --cluster NAME      Cluster name (default: mongodb-rs)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
+TARGET_TIME=""
+DRY_RUN=false
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+run() {
+  if [ "${DRY_RUN}" = true ]; then
+    log "[DRY-RUN] $*"
+  else
+    log "Running: $*"
+    "$@"
+  fi
+}
+
+usage() {
+  grep '^#' "${BASH_SOURCE[0]}" | grep -v '!/usr/bin' | sed 's/^# \?//'
+  exit 0
+}
+
+# ──────────────────────────────────────────────
+# Argument parsing
+# ──────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help) usage ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --target-time) TARGET_TIME="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+    *) log "ERROR: Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+# ──────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────
+
+validate_inputs() {
+  if [ -z "${TARGET_TIME}" ]; then
+    log "ERROR: --target-time is required"
+    log "Example: --target-time 2024-01-15T14:30:00Z"
+    exit 2
+  fi
+
+  # Validate ISO 8601 format
+  if ! date -d "${TARGET_TIME}" &>/dev/null 2>&1; then
+    log "ERROR: Invalid date format: ${TARGET_TIME}"
+    log "Expected ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ"
+    exit 2
+  fi
+
+  log "Target restore time: ${TARGET_TIME}"
+}
+
+check_prerequisites() {
+  local missing=()
+  for cmd in kubectl jq; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      missing+=("${cmd}")
+    fi
+  done
+  if [ ${#missing[@]} -gt 0 ]; then
+    log "ERROR: Missing required tools: ${missing[*]}"
+    exit 3
+  fi
+
+  if ! kubectl get psmdb "${CLUSTER_NAME}" -n "${NAMESPACE}" &>/dev/null; then
+    log "ERROR: PerconaServerMongoDB '${CLUSTER_NAME}' not found in namespace '${NAMESPACE}'"
+    exit 3
+  fi
+}
+
+check_pitr_available() {
+  log "Checking if PITR is available for target time..."
+
+  local pitr_status
+  pitr_status=$(kubectl get psmdb "${CLUSTER_NAME}" -n "${NAMESPACE}" \
+    -o jsonpath='{.status.pitr.enabled}' 2>/dev/null || echo "false")
+
+  if [ "${pitr_status}" != "true" ]; then
+    log "WARNING: PITR may not be enabled on this cluster."
+    log "Verify spec.backup.pitr.enabled is set to true in the CR."
+  fi
+}
+
+# ──────────────────────────────────────────────
+# Restore
+# ──────────────────────────────────────────────
+
+perform_pitr_restore() {
+  log "Starting Point-in-Time Recovery to ${TARGET_TIME}..."
+
+  local restore_name="pitr-restore-$(date +%Y%m%d-%H%M%S)"
+
+  run kubectl apply -f - <<EOF
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDBRestore
+metadata:
+  name: ${restore_name}
+  namespace: ${NAMESPACE}
+spec:
+  clusterName: ${CLUSTER_NAME}
+  pitr:
+    type: date
+    date: "${TARGET_TIME}"
+EOF
+
+  log "PITR restore CR '${restore_name}' created."
+  log "Waiting for PITR restore to complete..."
+
+  run kubectl wait --for=jsonpath='{.status.state}'=ready \
+    "psmdb-restore/${restore_name}" \
+    -n "${NAMESPACE}" \
+    --timeout=900s
+
+  log "PITR restore completed successfully."
+}
+
+# ──────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────
+
+validate_restore() {
+  log "Running post-restore validation..."
+  run bash "${SCRIPT_DIR}/validate-integrity.sh" \
+    --namespace "${NAMESPACE}" \
+    --cluster "${CLUSTER_NAME}"
+  log "Validation complete."
+}
+
+# ──────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────
+
+main() {
+  log "=== MongoDB Point-in-Time Recovery ==="
+
+  validate_inputs
+  check_prerequisites
+  check_pitr_available
+  perform_pitr_restore
+  validate_restore
+
+  log "=== PITR completed successfully ==="
+}
+
+main

--- a/backup/restore/validate-integrity.sh
+++ b/backup/restore/validate-integrity.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-integrity.sh - Post-restore data integrity validation
+#
+# Usage:
+#   ./backup/restore/validate-integrity.sh [OPTIONS]
+#
+# Options:
+#   --help              Show this help message
+#   --dry-run           Print commands without executing
+#   --namespace NS      MongoDB namespace (default: mongodb)
+#   --cluster NAME      Cluster name (default: mongodb-rs)
+#
+# Validation checks:
+#   1. dbHash consistency across replica set members
+#   2. Collection count verification
+#   3. Index consistency check
+#   4. Basic read operation test
+
+# Configuration
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
+RS_NAME="${RS_NAME:-rs0}"
+DRY_RUN=false
+ERRORS=0
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+pass() { log "PASS: $*"; }
+fail() { log "FAIL: $*"; ERRORS=$((ERRORS + 1)); }
+
+run() {
+  if [ "${DRY_RUN}" = true ]; then
+    log "[DRY-RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+usage() {
+  grep '^#' "${BASH_SOURCE[0]}" | grep -v '!/usr/bin' | sed 's/^# \?//'
+  exit 0
+}
+
+run_mongosh() {
+  local pod="${CLUSTER_NAME}-${RS_NAME}-0"
+  kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
+    mongosh --quiet --eval "$1" 2>/dev/null
+}
+
+# ──────────────────────────────────────────────
+# Argument parsing
+# ──────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help) usage ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --cluster) CLUSTER_NAME="$2"; shift 2 ;;
+    *) log "ERROR: Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+# ──────────────────────────────────────────────
+# Checks
+# ──────────────────────────────────────────────
+
+check_replica_set_health() {
+  log "Checking replica set health..."
+  local rs_ok
+  rs_ok=$(run_mongosh "rs.status().ok" || echo "0")
+  if [ "${rs_ok}" = "1" ]; then
+    pass "Replica set is healthy (rs.status().ok = 1)"
+  else
+    fail "Replica set is not healthy (rs.status().ok = ${rs_ok})"
+  fi
+}
+
+check_dbhash_consistency() {
+  log "Checking dbHash consistency across members..."
+  local hash_result
+  hash_result=$(run_mongosh "
+    const dbs = db.adminCommand({ listDatabases: 1 }).databases
+      .filter(d => !['admin', 'config', 'local'].includes(d.name))
+      .map(d => d.name);
+
+    let consistent = true;
+    for (const dbName of dbs) {
+      const hashResult = db.getSiblingDB(dbName).runCommand({ dbHash: 1 });
+      if (!hashResult.ok) {
+        print('ERROR: dbHash failed for ' + dbName);
+        consistent = false;
+      }
+    }
+    print(consistent ? 'consistent' : 'inconsistent');
+  " || echo "error")
+
+  if [ "${hash_result}" = "consistent" ]; then
+    pass "dbHash is consistent across all user databases"
+  elif [ "${hash_result}" = "error" ]; then
+    fail "dbHash check could not be executed"
+  else
+    fail "dbHash inconsistency detected"
+  fi
+}
+
+check_collection_counts() {
+  log "Checking collection counts..."
+  local db_count
+  db_count=$(run_mongosh "
+    const dbs = db.adminCommand({ listDatabases: 1 }).databases
+      .filter(d => !['admin', 'config', 'local'].includes(d.name));
+    let totalCollections = 0;
+    for (const dbInfo of dbs) {
+      const colls = db.getSiblingDB(dbInfo.name).getCollectionNames();
+      totalCollections += colls.length;
+    }
+    print(totalCollections);
+  " || echo "0")
+
+  if [ "${db_count}" -ge 0 ] 2>/dev/null; then
+    pass "Found ${db_count} collections across user databases"
+  else
+    fail "Could not enumerate collections"
+  fi
+}
+
+check_index_consistency() {
+  log "Checking index consistency..."
+  local index_result
+  index_result=$(run_mongosh "
+    const dbs = db.adminCommand({ listDatabases: 1 }).databases
+      .filter(d => !['admin', 'config', 'local'].includes(d.name));
+    let allValid = true;
+    for (const dbInfo of dbs) {
+      const sdb = db.getSiblingDB(dbInfo.name);
+      const colls = sdb.getCollectionNames();
+      for (const coll of colls) {
+        const result = sdb.getCollection(coll).validate({ full: false });
+        if (!result.valid) {
+          print('INVALID: ' + dbInfo.name + '.' + coll);
+          allValid = false;
+        }
+      }
+    }
+    print(allValid ? 'valid' : 'invalid');
+  " || echo "error")
+
+  if [ "${index_result}" = "valid" ]; then
+    pass "All collection indexes are valid"
+  elif [ "${index_result}" = "error" ]; then
+    fail "Index validation could not be executed"
+  else
+    fail "Index inconsistency detected"
+  fi
+}
+
+check_read_operations() {
+  log "Checking read operations..."
+  local read_result
+  read_result=$(run_mongosh "
+    try {
+      db.getSiblingDB('admin').runCommand({ ping: 1 });
+      print('ok');
+    } catch(e) {
+      print('error: ' + e.message);
+    }
+  " || echo "error")
+
+  if [ "${read_result}" = "ok" ]; then
+    pass "Read operations are functional"
+  else
+    fail "Read operations failed: ${read_result}"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────
+
+main() {
+  log "=== Post-Restore Integrity Validation ==="
+  log "Cluster: ${CLUSTER_NAME} | Namespace: ${NAMESPACE}"
+  log ""
+
+  check_replica_set_health
+  check_dbhash_consistency
+  check_collection_counts
+  check_index_consistency
+  check_read_operations
+
+  log ""
+  if [ "${ERRORS}" -eq 0 ]; then
+    log "=== All integrity checks passed ==="
+    exit 0
+  else
+    log "=== ${ERRORS} integrity check(s) FAILED ==="
+    exit 1
+  fi
+}
+
+main


### PR DESCRIPTION
## Summary
- Add `backup/restore/restore-full.sh` for full snapshot restore
- Add `backup/restore/restore-pitr.sh` for point-in-time recovery
- Add `backup/restore/validate-integrity.sh` with dbHash, collection count, index, and read checks

## Test plan
- [ ] Verify all scripts pass shellcheck
- [ ] Verify `--help` and `--dry-run` flags work
- [ ] Run full restore cycle on a test cluster

Closes #22