### PR TITLE
feat(tenancy): namespace template, NetworkPolicy, ResourceQuota, LimitRange

### DIFF
--- a/self-service/tenancy/limit-range.yaml
+++ b/self-service/tenancy/limit-range.yaml
@@ -1,0 +1,40 @@
+---
+# LimitRange for tenant namespaces.
+# Sets default resource requests/limits for containers that do not
+# specify their own, and enforces maximum resource caps per container.
+#
+# Default values match the Medium (M) t-shirt size profile.
+# Adjust per namespace based on the provisioned size (see ADR-005).
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: tenant-limits
+  labels:
+    app.kubernetes.io/name: tenant-limits
+    app.kubernetes.io/component: governance
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Default and maximum resource limits for containers in tenant
+      namespaces. Prevents pods from consuming unbounded resources.
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "1"
+        memory: 2Gi
+      defaultRequest:
+        cpu: 500m
+        memory: 1Gi
+      max:
+        cpu: "4"
+        memory: 8Gi
+      min:
+        cpu: 100m
+        memory: 128Mi
+    - type: PersistentVolumeClaim
+      max:
+        storage: 100Gi
+      min:
+        storage: 1Gi

--- a/self-service/tenancy/namespace-template.yaml
+++ b/self-service/tenancy/namespace-template.yaml
@@ -1,0 +1,23 @@
+---
+# Namespace template for tenant MongoDB instances.
+# This template is applied by the Crossplane Composition or manually
+# for teams that require a pre-provisioned namespace.
+#
+# Replace TEAM_NAME and ENVIRONMENT with actual values.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mongodb-TEAM_NAME-ENVIRONMENT
+  labels:
+    app.kubernetes.io/name: mongodb-TEAM_NAME-ENVIRONMENT
+    app.kubernetes.io/component: namespace
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+    dbaas.platform.local/tenant: "true"
+    dbaas.platform.local/team: TEAM_NAME
+    dbaas.platform.local/environment: ENVIRONMENT
+  annotations:
+    description: >-
+      Tenant namespace for team TEAM_NAME in the ENVIRONMENT environment.
+      Provisioned as part of the MongoDB DBaaS self-service platform.
+    owner: TEAM_NAME

--- a/self-service/tenancy/network-policy.yaml
+++ b/self-service/tenancy/network-policy.yaml
@@ -1,0 +1,75 @@
+---
+# NetworkPolicy for tenant namespace isolation.
+# Applied to every tenant namespace to enforce:
+#   - Intra-namespace communication (MongoDB RS members)
+#   - Monitoring namespace access (Prometheus scraping on port 9216)
+#   - DNS resolution (kube-dns/CoreDNS)
+#   - Operator namespace access (Percona operator reconciliation)
+#   - All other ingress/egress denied by default
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tenant-isolation
+  labels:
+    app.kubernetes.io/name: tenant-isolation
+    app.kubernetes.io/component: network
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Default deny with selective allow for MongoDB replica set
+      communication, monitoring, DNS, and operator access.
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow all traffic within the same namespace (RS member communication)
+    - from:
+        - podSelector: {}
+
+    # Allow Prometheus scraping from the monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9216
+
+    # Allow operator webhook/reconciliation from operator namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mongodb-operator
+
+  egress:
+    # Allow DNS resolution (UDP and TCP)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # Allow traffic within the same namespace
+    - to:
+        - podSelector: {}
+
+    # Allow traffic to the MongoDB operator namespace
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mongodb-operator
+
+    # Allow traffic to backup storage (MinIO/S3)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mongodb
+      ports:
+        - protocol: TCP
+          port: 9000

--- a/self-service/tenancy/resource-quota.yaml
+++ b/self-service/tenancy/resource-quota.yaml
@@ -1,0 +1,38 @@
+---
+# ResourceQuota template for tenant namespaces.
+# Enforces upper bounds on compute, storage, and object counts.
+# Values should be scaled based on the t-shirt size (see ADR-005):
+#   S: 2 CPU / 4Gi mem / 40Gi storage
+#   M: 4 CPU / 8Gi mem / 80Gi storage
+#   L: 8 CPU / 16Gi mem / 200Gi storage
+#
+# These represent 2x the instance profile to allow for headroom
+# during rolling updates and backup operations.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: tenant-quota
+  labels:
+    app.kubernetes.io/name: tenant-quota
+    app.kubernetes.io/component: governance
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Resource quota for tenant namespace. Limits total compute,
+      storage, and pod count to prevent resource exhaustion.
+spec:
+  hard:
+    # Compute resources (adjust per t-shirt size)
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    # Storage
+    persistentvolumeclaims: "5"
+    requests.storage: 80Gi
+    # Object count limits
+    pods: "10"
+    services: "5"
+    secrets: "20"
+    configmaps: "10"


### PR DESCRIPTION
## Summary

- Adds `self-service/tenancy/namespace-template.yaml` - template with team/environment labels and tenant marker
- Adds `self-service/tenancy/network-policy.yaml` - default-deny with selective allow for RS communication, Prometheus scraping (9216), DNS, operator access, and MinIO backup storage
- Adds `self-service/tenancy/resource-quota.yaml` - size-scaled compute, storage, and object count limits (2x instance profile)
- Adds `self-service/tenancy/limit-range.yaml` - container defaults, maximums, minimums, and PVC storage caps

## Test plan

- [ ] `yamllint self-service/tenancy/*.yaml`
- [ ] Verify NetworkPolicy ports match exporter (9216), MinIO (9000), and DNS (53)
- [ ] Validate ResourceQuota values align with ADR-005 size profiles

Closes #30