### PR TITLE
feat(monitoring): MongoDB exporter, ServiceMonitor, and recording rules

### DIFF
--- a/observability/prometheus/mongodb-exporter.yaml
+++ b/observability/prometheus/mongodb-exporter.yaml
@@ -1,0 +1,60 @@
+---
+# MongoDB Exporter configuration for Percona Server for MongoDB Operator.
+# The Percona Operator natively supports the mongodb-exporter sidecar.
+# This ConfigMap documents the exporter settings referenced in the PSMDB CR.
+#
+# The actual exporter is enabled via the PSMDB CR spec.pmm section or
+# spec.replsets[].sidecars when using standalone exporter deployments.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-exporter-config
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Configuration reference for the mongodb-exporter sidecar.
+      The Percona Operator automatically deploys the exporter when
+      monitoring is enabled in the PSMDB CR.
+data:
+  # Exporter configuration reference
+  # These settings are applied via the PSMDB CR, not directly via this ConfigMap.
+  exporter-notes: |
+    MongoDB Exporter Settings:
+    - Image: percona/mongodb_exporter:0.40.0
+    - Port: 9216 (metrics endpoint)
+    - Collectors enabled:
+      - diagnosticdata (serverStatus, replSetGetStatus)
+      - replicasetstatus (RS member state, lag)
+      - dbstats (per-database statistics)
+      - collstats (collection-level stats for top collections)
+      - indexstats (index usage statistics)
+      - topmetrics (operation counters per collection)
+    - Scrape interval: 30s (configured in ServiceMonitor)
+    - TLS: uses same certificates as MongoDB for secure scraping
+
+  # PSMDB CR snippet for enabling the exporter
+  psmdb-cr-snippet: |
+    spec:
+      replsets:
+        - name: rs0
+          sidecars:
+            - image: percona/mongodb_exporter:0.40.0
+              name: mongodb-exporter
+              args:
+                - "--mongodb.uri=mongodb://localhost:27017"
+                - "--compatible-mode"
+                - "--collector.diagnosticdata"
+                - "--collector.replicasetstatus"
+                - "--collector.dbstats"
+                - "--collector.collstats"
+                - "--collector.indexstats"
+                - "--collector.topmetrics"
+                - "--web.listen-address=:9216"
+              ports:
+                - containerPort: 9216
+                  name: metrics

--- a/observability/prometheus/prometheus-rules.yaml
+++ b/observability/prometheus/prometheus-rules.yaml
@@ -1,0 +1,71 @@
+---
+# PrometheusRule for MongoDB recording rules.
+# These pre-compute frequently used metrics to improve
+# dashboard performance and alert evaluation speed.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mongodb-recording-rules
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-recording-rules
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+    release: prometheus
+  annotations:
+    description: >-
+      Recording rules for MongoDB metrics. Pre-computes replication lag,
+      connection utilization, operation rates, and cache hit ratios.
+spec:
+  groups:
+    - name: mongodb.recording.rules
+      interval: 30s
+      rules:
+        # Replication lag in seconds
+        - record: mongodb:replication_lag:seconds
+          expr: |
+            mongodb_mongod_replset_member_optime_date{state="PRIMARY"}
+            - on(set) group_left()
+            mongodb_mongod_replset_member_optime_date{state="SECONDARY"}
+
+        # Operations per second by type (insert, query, update, delete, command)
+        - record: mongodb:opcounters:rate5m
+          expr: |
+            rate(mongodb_mongod_metrics_document_total[5m])
+
+        # Connection utilization percentage
+        - record: mongodb:connections:utilization_percent
+          expr: |
+            (mongodb_mongod_connections{state="current"}
+            / mongodb_mongod_connections{state="available"}) * 100
+
+        # WiredTiger cache hit ratio
+        - record: mongodb:wiredtiger:cache_hit_ratio
+          expr: |
+            rate(mongodb_mongod_wiredtiger_cache_bytes_read_into_total[5m])
+            / (rate(mongodb_mongod_wiredtiger_cache_bytes_read_into_total[5m])
+            + rate(mongodb_mongod_wiredtiger_cache_bytes_written_from_total[5m]))
+
+        # WiredTiger dirty cache percentage
+        - record: mongodb:wiredtiger:dirty_cache_percent
+          expr: |
+            (mongodb_mongod_wiredtiger_cache_tracked_dirty_bytes
+            / mongodb_mongod_wiredtiger_cache_max_bytes) * 100
+
+        # Average query execution time (from slow query profiler)
+        - record: mongodb:query:avg_execution_ms
+          expr: |
+            rate(mongodb_mongod_op_latencies_latency_total{type="reads"}[5m])
+            / rate(mongodb_mongod_op_latencies_ops_total{type="reads"}[5m])
+            / 1000
+
+        # Total data size across all databases (GB)
+        - record: mongodb:storage:data_size_gb
+          expr: |
+            sum(mongodb_mongod_db_stats_data_size) / 1073741824
+
+        # Tickets available (read/write) - indicates concurrency pressure
+        - record: mongodb:wiredtiger:tickets_available
+          expr: |
+            mongodb_mongod_wiredtiger_concurrent_transactions_available_tickets

--- a/observability/prometheus/servicemonitor.yaml
+++ b/observability/prometheus/servicemonitor.yaml
@@ -1,0 +1,68 @@
+---
+# ServiceMonitor for Prometheus to scrape MongoDB exporter metrics.
+# Targets all MongoDB pods exposing metrics on port 9216.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mongodb-exporter
+  namespace: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb-exporter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+    release: prometheus
+  annotations:
+    description: >-
+      Prometheus ServiceMonitor for MongoDB exporter. Scrapes metrics
+      from the mongodb-exporter sidecar on all replica set members.
+spec:
+  jobLabel: mongodb
+  namespaceSelector:
+    matchNames:
+      - mongodb
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+  endpoints:
+    - port: metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      path: /metrics
+      honorLabels: true
+      metricRelabelings:
+        # Drop high-cardinality metrics to control storage
+        - sourceLabels: [__name__]
+          regex: "mongodb_mongod_metrics_cursor_.*"
+          action: drop
+---
+# ServiceMonitor for sharded cluster mongos instances
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mongodb-mongos-exporter
+  namespace: mongodb-sharded
+  labels:
+    app.kubernetes.io/name: mongodb-mongos-exporter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+    release: prometheus
+  annotations:
+    description: >-
+      Prometheus ServiceMonitor for MongoDB mongos exporter.
+      Scrapes metrics from mongos router instances.
+spec:
+  jobLabel: mongodb-mongos
+  namespaceSelector:
+    matchNames:
+      - mongodb-sharded
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongos
+  endpoints:
+    - port: metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      path: /metrics
+      honorLabels: true


### PR DESCRIPTION
## Summary

- Adds `observability/prometheus/mongodb-exporter.yaml` - exporter config reference with PSMDB CR snippet (percona/mongodb_exporter:0.40.0, port 9216)
- Adds `observability/prometheus/servicemonitor.yaml` - ServiceMonitors for RS members and mongos (30s interval, high-cardinality drops)
- Adds `observability/prometheus/prometheus-rules.yaml` - 8 recording rules: replication lag, op counters, connection utilization, WiredTiger cache hit/dirty ratio, query latency, data size, ticket availability

## Test plan

- [ ] `yamllint observability/prometheus/*.yaml`
- [ ] Verify ServiceMonitor label selectors match Percona operator pod labels
- [ ] Validate PromQL expressions in recording rules

Closes #34