### PR TITLE
feat(logging): Fluent Bit + Loki MongoDB log pipeline

### DIFF
--- a/observability/logging/fluent-bit-config.yaml
+++ b/observability/logging/fluent-bit-config.yaml
@@ -1,0 +1,93 @@
+---
+# Fluent Bit configuration for MongoDB log collection and parsing.
+# Collects logs from mongod, backup-agent, and mongos containers,
+# parses MongoDB JSON structured logs, and forwards to Loki.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Fluent Bit configuration for MongoDB log collection.
+      Parses MongoDB structured JSON logs and forwards to Loki
+      with namespace, pod, and component labels.
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Daemon        Off
+        Flush         5
+        Log_Level     info
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+        Health_Check  On
+
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*mongodb*.log
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     10MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix     kube.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_parsed
+        Keep_Log            Off
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
+        Labels              On
+        Annotations         Off
+
+    [FILTER]
+        Name    grep
+        Match   kube.*
+        Regex   $kubernetes['namespace_name'] ^mongodb
+
+    [FILTER]
+        Name          parser
+        Match         kube.*
+        Key_Name      log
+        Parser        mongodb-json
+        Reserve_Data  On
+
+    [OUTPUT]
+        Name          loki
+        Match         kube.*
+        Host          loki.logging.svc.cluster.local
+        Port          3100
+        Labels        job=mongodb, namespace=$kubernetes['namespace_name'], pod=$kubernetes['pod_name'], container=$kubernetes['container_name']
+        Remove_Keys   $kubernetes
+        Auto_Kubernetes_Labels Off
+        Line_Format   json
+
+  parsers.conf: |
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+
+    [PARSER]
+        Name        mongodb-json
+        Format      json
+        Time_Key    t
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep   On
+        Types       s:string c:string ctx:string msg:string

--- a/observability/logging/fluent-bit-daemonset.yaml
+++ b/observability/logging/fluent-bit-daemonset.yaml
@@ -1,0 +1,128 @@
+---
+# Fluent Bit DaemonSet for MongoDB log collection.
+# Runs on every node to collect container logs from MongoDB namespaces
+# and forward them to Loki for centralized log aggregation.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+  annotations:
+    description: >-
+      Fluent Bit log collector DaemonSet. Collects MongoDB container
+      logs and forwards to Loki with structured parsing.
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: fluent-bit
+        app.kubernetes.io/component: logging
+        app.kubernetes.io/part-of: mongodb-dbaas-platform
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2020"
+        prometheus.io/path: "/api/v1/metrics/prometheus"
+    spec:
+      serviceAccountName: fluent-bit
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      containers:
+        - name: fluent-bit
+          image: fluent/fluent-bit:3.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 2020
+              name: http-metrics
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: config
+              mountPath: /fluent-bit/etc/
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http-metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http-metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: config
+          configMap:
+            name: fluent-bit-config
+---
+# ServiceAccount for Fluent Bit
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+---
+# ClusterRole for Fluent Bit (read pods and namespaces)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# ClusterRoleBinding for Fluent Bit
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: logging

--- a/observability/logging/loki-datasource.yaml
+++ b/observability/logging/loki-datasource.yaml
@@ -1,0 +1,41 @@
+---
+# Grafana datasource configuration for Loki.
+# Auto-provisions Loki as a datasource when deployed alongside Grafana.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-loki-datasource
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: grafana-loki-datasource
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: platform-team
+    grafana_datasource: "true"
+  annotations:
+    description: >-
+      Grafana datasource provisioning for Loki. Enables log exploration
+      and correlation with Prometheus metrics in Grafana dashboards.
+data:
+  loki-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.logging.svc.cluster.local:3100
+        isDefault: false
+        jsonData:
+          maxLines: 1000
+          timeout: 60
+          derivedFields:
+            - datasourceUid: prometheus
+              matcherRegex: '"namespace":"(.*?)"'
+              name: Namespace
+              url: '/explore?orgId=1&left=["now-1h","now","Loki",{"expr":"{namespace=\"${__value.raw}\"}"}]'
+            - datasourceUid: prometheus
+              matcherRegex: '"pod":"(.*?)"'
+              name: Pod
+              url: '/explore?orgId=1&left=["now-1h","now","Loki",{"expr":"{pod=\"${__value.raw}\"}"}]'
+        version: 1
+        editable: true


### PR DESCRIPTION
## Summary

- Adds `observability/logging/fluent-bit-config.yaml` - input (tail MongoDB containers), kubernetes filter, MongoDB JSON parser, Loki output with namespace/pod/container labels
- Adds `observability/logging/fluent-bit-daemonset.yaml` - DaemonSet (fluent/fluent-bit:3.0), ServiceAccount, ClusterRole/Binding, health probes, Prometheus metrics
- Adds `observability/logging/loki-datasource.yaml` - Grafana auto-provisioning with derived fields for namespace/pod correlation

## Test plan

- [ ] `yamllint observability/logging/*.yaml`
- [ ] Verify Fluent Bit config parses MongoDB JSON log format (`t`, `s`, `c`, `ctx`, `msg` fields)
- [ ] Validate Loki datasource URL matches logging namespace service

Closes #37