### PR TITLE
feat(cdc): Strimzi Kafka cluster and CDC topics

### DIFF
--- a/cdc/kafka/kafka-cluster.yaml
+++ b/cdc/kafka/kafka-cluster.yaml
@@ -1,0 +1,137 @@
+---
+# Strimzi Kafka cluster for CDC event streaming.
+# 3-broker cluster with KRaft (no ZooKeeper) for metadata management.
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: mongodb-cdc
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: mongodb-cdc
+    app.kubernetes.io/component: cdc
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: strimzi
+  annotations:
+    description: >-
+      Kafka cluster for MongoDB CDC pipeline. Receives change events
+      from Debezium and distributes them to downstream consumers.
+spec:
+  kafka:
+    version: 3.7.0
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      # Replication factors for internal topics
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      # Log retention
+      log.retention.hours: 168  # 7 days
+      log.retention.bytes: -1
+      log.segment.bytes: 1073741824  # 1 GB
+      # Performance tuning
+      num.partitions: 3
+      num.network.threads: 3
+      num.io.threads: 8
+      socket.send.buffer.bytes: 102400
+      socket.receive.buffer.bytes: 102400
+      socket.request.max.bytes: 104857600
+      group.initial.rebalance.delay.ms: 3000
+    storage:
+      type: persistent-claim
+      size: 10Gi
+      class: local-path
+      deleteClaim: false
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics
+          key: kafka-metrics-config.yml
+
+  # KRaft metadata (replaces ZooKeeper)
+  zookeeper:
+    replicas: 3
+    storage:
+      type: persistent-claim
+      size: 5Gi
+      class: local-path
+      deleteClaim: false
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+
+  entityOperator:
+    topicOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 250m
+          memory: 512Mi
+    userOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 250m
+          memory: 512Mi
+---
+# Kafka metrics ConfigMap for Prometheus JMX exporter
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-metrics
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: kafka-metrics
+    app.kubernetes.io/component: cdc
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: strimzi
+data:
+  kafka-metrics-config.yml: |
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    rules:
+      - pattern: "kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)>Value"
+        name: "kafka_server_$1_$2"
+        type: GAUGE
+        labels:
+          clientId: "$3"
+          topic: "$4"
+          partition: "$5"
+      - pattern: "kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)>Value"
+        name: "kafka_server_$1_$2"
+        type: GAUGE
+        labels:
+          clientId: "$3"
+          broker: "$4:$5"
+      - pattern: "kafka.server<type=(.+), name=(.+)>Value"
+        name: "kafka_server_$1_$2"
+        type: GAUGE
+      - pattern: "kafka.server<type=(.+), name=(.+)>Count"
+        name: "kafka_server_$1_$2_total"
+        type: COUNTER

--- a/cdc/kafka/kafka-topic.yaml
+++ b/cdc/kafka/kafka-topic.yaml
@@ -1,0 +1,53 @@
+---
+# Kafka topic for MongoDB CDC events.
+# Debezium creates topics automatically per collection, but this
+# pre-creates the main topic with specific retention and partition settings.
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: mongodb.backup-test.validation-data
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: mongodb-cdc-topic
+    app.kubernetes.io/component: cdc
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: strimzi
+    strimzi.io/cluster: mongodb-cdc
+  annotations:
+    description: >-
+      CDC topic for MongoDB change events. Debezium publishes document
+      changes from the configured MongoDB collections to this topic.
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: 604800000  # 7 days
+    cleanup.policy: delete
+    min.insync.replicas: 2
+    compression.type: lz4
+    max.message.bytes: 10485760  # 10 MB
+    segment.bytes: 1073741824  # 1 GB
+---
+# Dead letter queue topic for failed CDC events
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: mongodb-cdc-dlq
+  namespace: kafka
+  labels:
+    app.kubernetes.io/name: mongodb-cdc-dlq
+    app.kubernetes.io/component: cdc
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: strimzi
+    strimzi.io/cluster: mongodb-cdc
+  annotations:
+    description: >-
+      Dead letter queue for CDC events that failed processing.
+      Events are retained for 30 days for investigation.
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 2592000000  # 30 days
+    cleanup.policy: delete
+    min.insync.replicas: 2

--- a/cdc/kafka/strimzi-operator.yaml
+++ b/cdc/kafka/strimzi-operator.yaml
@@ -1,0 +1,22 @@
+---
+# Strimzi Kafka Operator namespace and deployment reference.
+# The Strimzi operator manages Kafka clusters, topics, users, and
+# Kafka Connect instances as Kubernetes Custom Resources.
+#
+# Installation via Helm:
+#   helm repo add strimzi https://strimzi.io/charts/
+#   helm install strimzi-kafka-operator strimzi/strimzi-kafka-operator \
+#     --namespace kafka --create-namespace --wait
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka
+  labels:
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: cdc
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: strimzi
+  annotations:
+    description: >-
+      Namespace for the Strimzi Kafka operator and CDC pipeline components.
+      Hosts Kafka brokers, Kafka Connect, and Debezium connectors.


### PR DESCRIPTION
## Summary

- Adds `cdc/kafka/strimzi-operator.yaml` - Kafka namespace with Helm install reference
- Adds `cdc/kafka/kafka-cluster.yaml` - 3-broker Kafka cluster (3.7.0), ZooKeeper (3 nodes), entity operator, JMX Prometheus exporter, persistent storage, ISR=2
- Adds `cdc/kafka/kafka-topic.yaml` - CDC event topic (3 partitions, 3 replicas, 7-day retention, lz4) and DLQ topic (30-day retention)

## Test plan

- [ ] `yamllint cdc/kafka/*.yaml`
- [ ] Verify Kafka resource limits are appropriate for kind cluster
- [ ] Validate topic partition count and replication factor

Closes #39