### PR TITLE
test(dr): chaos testing scripts for primary kill, PV delete, network partition

### DIFF
--- a/tests/chaos/delete-pv.sh
+++ b/tests/chaos/delete-pv.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# delete-pv.sh - Simulate persistent volume loss for a MongoDB secondary
+# member and validate automatic recovery with initial sync.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# Defaults
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+RS_NAME="${RS_NAME:-rs0}"
+DRY_RUN=false
+RECOVERY_TIMEOUT=300
+SYNC_TIMEOUT=600
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+usage() {
+  cat <<HELP
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Simulate persistent volume loss for a MongoDB secondary member and validate
+that the member recovers via initial sync with no data loss.
+
+Options:
+  --namespace NAME         Kubernetes namespace (env: NAMESPACE, default: mongodb)
+  --cluster-name NAME      Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --rs-name NAME           Replica set name (env: RS_NAME, default: rs0)
+  --recovery-timeout SEC   Max seconds to wait for pod rescheduling (default: 300)
+  --sync-timeout SEC       Max seconds to wait for initial sync (default: 600)
+  --dry-run                Print commands without executing
+  --help                   Show this help message
+
+Environment variables:
+  NAMESPACE      Kubernetes namespace
+  CLUSTER_NAME   Percona cluster name
+  RS_NAME        Replica set name
+
+Exit codes:
+  0  Success
+  1  General error
+  2  Usage error
+  3  Precondition not met
+HELP
+}
+
+run() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+die() {
+  local code="$1"
+  shift
+  log "ERROR: $*" >&2
+  exit "${code}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      [[ -n "${2:-}" ]] || die 2 "--namespace requires a value"
+      NAMESPACE="$2"; shift 2 ;;
+    --cluster-name)
+      [[ -n "${2:-}" ]] || die 2 "--cluster-name requires a value"
+      CLUSTER_NAME="$2"; shift 2 ;;
+    --rs-name)
+      [[ -n "${2:-}" ]] || die 2 "--rs-name requires a value"
+      RS_NAME="$2"; shift 2 ;;
+    --recovery-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--recovery-timeout requires a value"
+      RECOVERY_TIMEOUT="$2"; shift 2 ;;
+    --sync-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--sync-timeout requires a value"
+      SYNC_TIMEOUT="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    --help)
+      usage; exit 0 ;;
+    *)
+      die 2 "Unknown option: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Precondition checks
+# ---------------------------------------------------------------------------
+
+check_preconditions() {
+  log "Checking preconditions..."
+
+  if ! command -v kubectl &>/dev/null; then
+    die 3 "kubectl is not installed or not in PATH"
+  fi
+
+  if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    die 3 "Namespace '${NAMESPACE}' does not exist"
+  fi
+
+  local pod_count
+  pod_count=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    --no-headers 2>/dev/null | wc -l)
+
+  if [[ "${pod_count}" -lt 3 ]]; then
+    die 3 "Expected at least 3 replica set pods, found ${pod_count}"
+  fi
+
+  log "Preconditions satisfied"
+}
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+mongo_eval() {
+  local pod="$1"
+  shift
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- \
+    mongosh --quiet --eval "$@" 2>/dev/null
+}
+
+find_primary() {
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  for pod in ${pods}; do
+    local is_master
+    is_master=$(mongo_eval "${pod}" 'db.isMaster().ismaster' 2>/dev/null || echo "false")
+    if [[ "${is_master}" == "true" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_secondary() {
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  local primary
+  primary=$(find_primary) || die 1 "Could not identify primary"
+
+  for pod in ${pods}; do
+    if [[ "${pod}" != "${primary}" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  die 1 "Could not find a secondary member"
+}
+
+get_pvc_for_pod() {
+  local pod="$1"
+  kubectl get pod -n "${NAMESPACE}" "${pod}" \
+    -o jsonpath='{.spec.volumes[?(@.persistentVolumeClaim)].persistentVolumeClaim.claimName}' 2>/dev/null \
+    | awk '{print $1}'
+}
+
+get_document_count() {
+  local pod="$1"
+  local db_name="${2:-chaos_test}"
+  local coll_name="${3:-pv_test}"
+  mongo_eval "${pod}" "db.getSiblingDB('${db_name}').${coll_name}.countDocuments({})"
+}
+
+record_pre_failure_state() {
+  log "Recording pre-failure state..."
+
+  PRIMARY_POD=$(find_primary) || die 1 "Could not identify primary"
+  log "Primary: ${PRIMARY_POD}"
+
+  TARGET_POD=$(find_secondary) || die 1 "Could not identify secondary"
+  log "Target secondary for PV deletion: ${TARGET_POD}"
+
+  TARGET_PVC=$(get_pvc_for_pod "${TARGET_POD}")
+  if [[ -z "${TARGET_PVC}" ]]; then
+    die 1 "Could not find PVC for pod ${TARGET_POD}"
+  fi
+  log "Target PVC: ${TARGET_PVC}"
+
+  # Insert test data and record count
+  log "Inserting test data for validation..."
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    mongo_eval "${PRIMARY_POD}" '
+      const db = db.getSiblingDB("chaos_test");
+      for (let i = 0; i < 100; i++) {
+        db.pv_test.insertOne(
+          {seq: i, ts: new Date(), data: "pv-delete-chaos-test"},
+          {writeConcern: {w: "majority", wtimeout: 10000}}
+        );
+      }
+    ' || die 1 "Failed to insert test data"
+
+    # Wait briefly for replication
+    sleep 5
+
+    DOC_COUNT_BEFORE=$(get_document_count "${PRIMARY_POD}") || die 1 "Failed to get document count"
+    log "Document count before failure: ${DOC_COUNT_BEFORE}"
+  else
+    DOC_COUNT_BEFORE=0
+    log "[DRY-RUN] Would insert test data and record count"
+  fi
+}
+
+delete_pvc_and_pod() {
+  log "Deleting PVC: ${TARGET_PVC}"
+  run kubectl delete pvc -n "${NAMESPACE}" "${TARGET_PVC}" --wait=false
+
+  log "Deleting pod: ${TARGET_POD}"
+  run kubectl delete pod -n "${NAMESPACE}" "${TARGET_POD}" --grace-period=0 --force
+
+  log "PVC and pod deletion initiated"
+}
+
+wait_for_pod_reschedule() {
+  log "Waiting up to ${RECOVERY_TIMEOUT}s for pod to be rescheduled..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for pod rescheduling"
+    return 0
+  fi
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${RECOVERY_TIMEOUT}" ]]; do
+    local phase
+    phase=$(kubectl get pod -n "${NAMESPACE}" "${TARGET_POD}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+    if [[ "${phase}" == "Running" ]]; then
+      local ready
+      ready=$(kubectl get pod -n "${NAMESPACE}" "${TARGET_POD}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+
+      if [[ "${ready}" == "True" ]]; then
+        log "Pod rescheduled and is Ready (after ${elapsed}s)"
+        return 0
+      fi
+    fi
+
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  die 1 "Pod did not become Ready within ${RECOVERY_TIMEOUT}s"
+}
+
+wait_for_pvc_provision() {
+  log "Checking for PVC re-provisioning..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for PVC provisioning"
+    return 0
+  fi
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${RECOVERY_TIMEOUT}" ]]; do
+    local pvc_status
+    pvc_status=$(kubectl get pvc -n "${NAMESPACE}" "${TARGET_PVC}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+    if [[ "${pvc_status}" == "Bound" ]]; then
+      log "PVC re-provisioned and Bound (after ${elapsed}s)"
+      return 0
+    fi
+
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  die 1 "PVC was not re-provisioned within ${RECOVERY_TIMEOUT}s"
+}
+
+wait_for_initial_sync() {
+  log "Waiting up to ${SYNC_TIMEOUT}s for initial sync to complete..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for initial sync"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary) || die 1 "No primary available"
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${SYNC_TIMEOUT}" ]]; do
+    local member_state
+    member_state=$(mongo_eval "${primary}" "
+      const status = rs.status();
+      const member = status.members.find(m => m.name.includes('${TARGET_POD}'));
+      member ? member.stateStr : 'UNKNOWN';
+    " 2>/dev/null || echo "UNKNOWN")
+
+    if [[ "${member_state}" == "SECONDARY" ]]; then
+      log "Member completed initial sync and is SECONDARY (after ${elapsed}s)"
+      return 0
+    fi
+
+    log "Member state: ${member_state} (waiting for SECONDARY)..."
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  die 1 "Initial sync did not complete within ${SYNC_TIMEOUT}s"
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+validate_recovery() {
+  log "Running recovery validation..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would validate recovery"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary) || die 1 "No primary found after recovery"
+
+  # Check document count matches
+  local doc_count_after
+  doc_count_after=$(get_document_count "${primary}") || die 1 "Failed to get document count"
+
+  if [[ "${doc_count_after}" -lt "${DOC_COUNT_BEFORE}" ]]; then
+    die 1 "Data loss detected: expected >=${DOC_COUNT_BEFORE} documents, found ${doc_count_after}"
+  fi
+  log "Document count after recovery: ${doc_count_after} (before: ${DOC_COUNT_BEFORE})"
+
+  # Verify the recovered member has the same data
+  local secondary_count
+  secondary_count=$(get_document_count "${TARGET_POD}") || die 1 "Failed to get count from recovered member"
+
+  if [[ "${secondary_count}" -lt "${DOC_COUNT_BEFORE}" ]]; then
+    die 1 "Recovered member has incomplete data: expected >=${DOC_COUNT_BEFORE}, found ${secondary_count}"
+  fi
+  log "Recovered member document count: ${secondary_count}"
+
+  # Call validate-recovery.sh if available
+  if [[ -x "${SCRIPT_DIR}/validate-recovery.sh" ]]; then
+    log "Running comprehensive recovery validation..."
+    "${SCRIPT_DIR}/validate-recovery.sh" \
+      --namespace "${NAMESPACE}" \
+      --cluster-name "${CLUSTER_NAME}" \
+      --rs-name "${RS_NAME}"
+  fi
+
+  log "All validations passed"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    log "Cleaning up test data..."
+    local primary
+    primary=$(find_primary 2>/dev/null) || true
+    if [[ -n "${primary}" ]]; then
+      mongo_eval "${primary}" \
+        'db.getSiblingDB("chaos_test").pv_test.drop()' &>/dev/null || true
+    fi
+  fi
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  log "=== Delete PV Chaos Test ==="
+  log "Namespace: ${NAMESPACE}"
+  log "Cluster:   ${CLUSTER_NAME}"
+  log "RS Name:   ${RS_NAME}"
+  log "Dry Run:   ${DRY_RUN}"
+
+  check_preconditions
+  record_pre_failure_state
+  delete_pvc_and_pod
+  wait_for_pvc_provision
+  wait_for_pod_reschedule
+  wait_for_initial_sync
+  validate_recovery
+
+  log "=== Delete PV Chaos Test PASSED ==="
+}
+
+main

--- a/tests/chaos/kill-primary.sh
+++ b/tests/chaos/kill-primary.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# kill-primary.sh - Simulate primary pod failure and validate automatic
+# failover, re-election, pod recovery, and replication health.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# Defaults
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+RS_NAME="${RS_NAME:-rs0}"
+DRY_RUN=false
+ELECTION_TIMEOUT=60
+RECOVERY_TIMEOUT=120
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+usage() {
+  cat <<HELP
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Simulate a MongoDB primary pod failure and validate automatic recovery.
+
+Options:
+  --namespace NAME        Kubernetes namespace (env: NAMESPACE, default: mongodb)
+  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --rs-name NAME          Replica set name (env: RS_NAME, default: rs0)
+  --election-timeout SEC  Max seconds to wait for new primary (default: 60)
+  --recovery-timeout SEC  Max seconds to wait for old pod recovery (default: 120)
+  --dry-run               Print commands without executing
+  --help                  Show this help message
+
+Environment variables:
+  NAMESPACE      Kubernetes namespace
+  CLUSTER_NAME   Percona cluster name
+  RS_NAME        Replica set name
+
+Exit codes:
+  0  Success
+  1  General error
+  2  Usage error
+  3  Precondition not met
+HELP
+}
+
+run() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+die() {
+  local code="$1"
+  shift
+  log "ERROR: $*" >&2
+  exit "${code}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      [[ -n "${2:-}" ]] || die 2 "--namespace requires a value"
+      NAMESPACE="$2"; shift 2 ;;
+    --cluster-name)
+      [[ -n "${2:-}" ]] || die 2 "--cluster-name requires a value"
+      CLUSTER_NAME="$2"; shift 2 ;;
+    --rs-name)
+      [[ -n "${2:-}" ]] || die 2 "--rs-name requires a value"
+      RS_NAME="$2"; shift 2 ;;
+    --election-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--election-timeout requires a value"
+      ELECTION_TIMEOUT="$2"; shift 2 ;;
+    --recovery-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--recovery-timeout requires a value"
+      RECOVERY_TIMEOUT="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    --help)
+      usage; exit 0 ;;
+    *)
+      die 2 "Unknown option: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Precondition checks
+# ---------------------------------------------------------------------------
+
+check_preconditions() {
+  log "Checking preconditions..."
+
+  if ! command -v kubectl &>/dev/null; then
+    die 3 "kubectl is not installed or not in PATH"
+  fi
+
+  if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    die 3 "Namespace '${NAMESPACE}' does not exist"
+  fi
+
+  local pod_count
+  pod_count=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    --no-headers 2>/dev/null | wc -l)
+
+  if [[ "${pod_count}" -lt 3 ]]; then
+    die 3 "Expected at least 3 replica set pods, found ${pod_count}"
+  fi
+
+  log "Preconditions satisfied"
+}
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+get_mongo_pod() {
+  local index="${1:-0}"
+  kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath="{.items[${index}].metadata.name}" 2>/dev/null
+}
+
+mongo_eval() {
+  local pod="$1"
+  shift
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- \
+    mongosh --quiet --eval "$@" 2>/dev/null
+}
+
+find_primary() {
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  for pod in ${pods}; do
+    local is_master
+    is_master=$(mongo_eval "${pod}" 'db.isMaster().ismaster' 2>/dev/null || echo "false")
+    if [[ "${is_master}" == "true" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+get_oplog_position() {
+  local pod="$1"
+  mongo_eval "${pod}" 'rs.status().members.find(m => m.stateStr === "PRIMARY").optimeDate'
+}
+
+record_pre_failure_state() {
+  log "Recording pre-failure state..."
+
+  PRIMARY_POD=$(find_primary) || die 1 "Could not identify the current primary"
+  log "Current primary: ${PRIMARY_POD}"
+
+  OPLOG_POS=$(get_oplog_position "${PRIMARY_POD}") || true
+  log "Oplog position: ${OPLOG_POS:-unknown}"
+
+  RS_STATUS_BEFORE=$(mongo_eval "${PRIMARY_POD}" 'JSON.stringify(rs.status().members.map(m => ({name: m.name, state: m.stateStr})))') || true
+  log "RS members before: ${RS_STATUS_BEFORE:-unknown}"
+}
+
+kill_primary_pod() {
+  log "Deleting primary pod: ${PRIMARY_POD}"
+  run kubectl delete pod -n "${NAMESPACE}" "${PRIMARY_POD}" --grace-period=0 --force
+  log "Primary pod deletion initiated"
+}
+
+wait_for_new_primary() {
+  log "Waiting up to ${ELECTION_TIMEOUT}s for new primary election..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for new primary election"
+    return 0
+  fi
+
+  local elapsed=0
+  local new_primary=""
+
+  while [[ "${elapsed}" -lt "${ELECTION_TIMEOUT}" ]]; do
+    new_primary=$(find_primary 2>/dev/null) || true
+
+    if [[ -n "${new_primary}" && "${new_primary}" != "${PRIMARY_POD}" ]]; then
+      log "New primary elected: ${new_primary} (after ${elapsed}s)"
+      return 0
+    fi
+
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  die 1 "No new primary elected within ${ELECTION_TIMEOUT}s"
+}
+
+wait_for_pod_recovery() {
+  log "Waiting up to ${RECOVERY_TIMEOUT}s for old primary pod to recover: ${PRIMARY_POD}"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for pod recovery"
+    return 0
+  fi
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${RECOVERY_TIMEOUT}" ]]; do
+    local phase
+    phase=$(kubectl get pod -n "${NAMESPACE}" "${PRIMARY_POD}" \
+      -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+    if [[ "${phase}" == "Running" ]]; then
+      local ready
+      ready=$(kubectl get pod -n "${NAMESPACE}" "${PRIMARY_POD}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+
+      if [[ "${ready}" == "True" ]]; then
+        log "Old primary pod recovered and is Ready (after ${elapsed}s)"
+        return 0
+      fi
+    fi
+
+    sleep 3
+    elapsed=$((elapsed + 3))
+  done
+
+  die 1 "Old primary pod did not recover within ${RECOVERY_TIMEOUT}s"
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+validate_recovery() {
+  log "Running recovery validation..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would validate recovery"
+    return 0
+  fi
+
+  # Validate new primary exists and differs from old primary
+  local current_primary
+  current_primary=$(find_primary) || die 1 "No primary found after failover"
+
+  if [[ "${current_primary}" == "${PRIMARY_POD}" ]]; then
+    log "WARNING: Same pod became primary again (valid but unexpected)"
+  fi
+
+  # Check replication lag on all secondaries
+  log "Checking replication lag..."
+  local lag_check
+  lag_check=$(mongo_eval "${current_primary}" '
+    const status = rs.status();
+    const primary = status.members.find(m => m.stateStr === "PRIMARY");
+    const lagging = status.members.filter(m =>
+      m.stateStr === "SECONDARY" &&
+      (primary.optimeDate - m.optimeDate) / 1000 > 10
+    );
+    JSON.stringify({ok: lagging.length === 0, count: lagging.length});
+  ') || die 1 "Failed to check replication lag"
+
+  local lag_ok
+  lag_ok=$(echo "${lag_check}" | grep -o '"ok":true' || true)
+  if [[ -z "${lag_ok}" ]]; then
+    die 1 "Replication lag exceeds 10 seconds on one or more secondaries"
+  fi
+  log "Replication lag within acceptable threshold (<10s)"
+
+  # Validate majority write succeeds
+  log "Testing majority write concern..."
+  local write_result
+  write_result=$(mongo_eval "${current_primary}" '
+    try {
+      db.getSiblingDB("chaos_test").kill_primary_test.insertOne(
+        {test: "kill-primary", ts: new Date()},
+        {writeConcern: {w: "majority", wtimeout: 10000}}
+      );
+      "write_ok"
+    } catch(e) {
+      "write_failed: " + e.message
+    }
+  ') || die 1 "Failed to execute majority write test"
+
+  if [[ "${write_result}" != *"write_ok"* ]]; then
+    die 1 "Majority write failed after failover: ${write_result}"
+  fi
+  log "Majority write succeeded"
+
+  # Call validate-recovery.sh if available
+  if [[ -x "${SCRIPT_DIR}/validate-recovery.sh" ]]; then
+    log "Running comprehensive recovery validation..."
+    "${SCRIPT_DIR}/validate-recovery.sh" \
+      --namespace "${NAMESPACE}" \
+      --cluster-name "${CLUSTER_NAME}" \
+      --rs-name "${RS_NAME}"
+  fi
+
+  log "All validations passed"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    log "Cleaning up test data..."
+    local primary
+    primary=$(find_primary 2>/dev/null) || true
+    if [[ -n "${primary}" ]]; then
+      mongo_eval "${primary}" \
+        'db.getSiblingDB("chaos_test").kill_primary_test.drop()' &>/dev/null || true
+    fi
+  fi
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  log "=== Kill Primary Chaos Test ==="
+  log "Namespace: ${NAMESPACE}"
+  log "Cluster:   ${CLUSTER_NAME}"
+  log "RS Name:   ${RS_NAME}"
+  log "Dry Run:   ${DRY_RUN}"
+
+  check_preconditions
+  record_pre_failure_state
+  kill_primary_pod
+  wait_for_new_primary
+  wait_for_pod_recovery
+  validate_recovery
+
+  log "=== Kill Primary Chaos Test PASSED ==="
+}
+
+main

--- a/tests/chaos/network-partition.sh
+++ b/tests/chaos/network-partition.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# network-partition.sh - Simulate a network partition for one MongoDB
+# replica set member using iptables and validate recovery after healing.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# Defaults
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+RS_NAME="${RS_NAME:-rs0}"
+DRY_RUN=false
+PARTITION_DURATION=30
+DETECTION_TIMEOUT=60
+RECOVERY_TIMEOUT=120
+
+# State variables
+TARGET_POD=""
+TARGET_IP=""
+PEER_IPS=()
+PARTITION_APPLIED=false
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+usage() {
+  cat <<HELP
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Simulate a network partition for one MongoDB replica set member by blocking
+traffic with iptables, then heal the partition and validate recovery.
+
+This script requires the target pod to have iptables available. The Percona
+operator pods typically include iptables in their container image.
+
+Options:
+  --namespace NAME            Kubernetes namespace (env: NAMESPACE, default: mongodb)
+  --cluster-name NAME         Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --rs-name NAME              Replica set name (env: RS_NAME, default: rs0)
+  --partition-duration SEC    How long to maintain the partition (default: 30)
+  --detection-timeout SEC     Max seconds to detect membership loss (default: 60)
+  --recovery-timeout SEC      Max seconds to wait for recovery after healing (default: 120)
+  --dry-run                   Print commands without executing
+  --help                      Show this help message
+
+Environment variables:
+  NAMESPACE      Kubernetes namespace
+  CLUSTER_NAME   Percona cluster name
+  RS_NAME        Replica set name
+
+Exit codes:
+  0  Success
+  1  General error
+  2  Usage error
+  3  Precondition not met
+HELP
+}
+
+run() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+die() {
+  local code="$1"
+  shift
+  log "ERROR: $*" >&2
+  exit "${code}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      [[ -n "${2:-}" ]] || die 2 "--namespace requires a value"
+      NAMESPACE="$2"; shift 2 ;;
+    --cluster-name)
+      [[ -n "${2:-}" ]] || die 2 "--cluster-name requires a value"
+      CLUSTER_NAME="$2"; shift 2 ;;
+    --rs-name)
+      [[ -n "${2:-}" ]] || die 2 "--rs-name requires a value"
+      RS_NAME="$2"; shift 2 ;;
+    --partition-duration)
+      [[ -n "${2:-}" ]] || die 2 "--partition-duration requires a value"
+      PARTITION_DURATION="$2"; shift 2 ;;
+    --detection-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--detection-timeout requires a value"
+      DETECTION_TIMEOUT="$2"; shift 2 ;;
+    --recovery-timeout)
+      [[ -n "${2:-}" ]] || die 2 "--recovery-timeout requires a value"
+      RECOVERY_TIMEOUT="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    --help)
+      usage; exit 0 ;;
+    *)
+      die 2 "Unknown option: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Precondition checks
+# ---------------------------------------------------------------------------
+
+check_preconditions() {
+  log "Checking preconditions..."
+
+  if ! command -v kubectl &>/dev/null; then
+    die 3 "kubectl is not installed or not in PATH"
+  fi
+
+  if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    die 3 "Namespace '${NAMESPACE}' does not exist"
+  fi
+
+  local pod_count
+  pod_count=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    --no-headers 2>/dev/null | wc -l)
+
+  if [[ "${pod_count}" -lt 3 ]]; then
+    die 3 "Expected at least 3 replica set pods, found ${pod_count}"
+  fi
+
+  log "Preconditions satisfied"
+}
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+mongo_eval() {
+  local pod="$1"
+  shift
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- \
+    mongosh --quiet --eval "$@" 2>/dev/null
+}
+
+find_primary() {
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  for pod in ${pods}; do
+    local is_master
+    is_master=$(mongo_eval "${pod}" 'db.isMaster().ismaster' 2>/dev/null || echo "false")
+    if [[ "${is_master}" == "true" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_secondary() {
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  local primary
+  primary=$(find_primary) || die 1 "Could not identify primary"
+
+  for pod in ${pods}; do
+    if [[ "${pod}" != "${primary}" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  die 1 "Could not find a secondary member"
+}
+
+get_pod_ip() {
+  local pod="$1"
+  kubectl get pod -n "${NAMESPACE}" "${pod}" \
+    -o jsonpath='{.status.podIP}' 2>/dev/null
+}
+
+get_all_pod_ips() {
+  kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].status.podIP}' 2>/dev/null
+}
+
+select_target() {
+  log "Selecting partition target..."
+
+  TARGET_POD=$(find_secondary) || die 1 "Could not find a secondary to partition"
+  TARGET_IP=$(get_pod_ip "${TARGET_POD}")
+  log "Target pod: ${TARGET_POD} (IP: ${TARGET_IP})"
+
+  local all_ips
+  all_ips=$(get_all_pod_ips)
+
+  PEER_IPS=()
+  for ip in ${all_ips}; do
+    if [[ "${ip}" != "${TARGET_IP}" ]]; then
+      PEER_IPS+=("${ip}")
+    fi
+  done
+
+  log "Peer IPs: ${PEER_IPS[*]}"
+}
+
+insert_test_data() {
+  log "Inserting test data before partition..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would insert test data"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary) || die 1 "No primary available"
+
+  mongo_eval "${primary}" '
+    const db = db.getSiblingDB("chaos_test");
+    for (let i = 0; i < 50; i++) {
+      db.partition_test.insertOne(
+        {seq: i, phase: "pre-partition", ts: new Date()},
+        {writeConcern: {w: "majority", wtimeout: 10000}}
+      );
+    }
+  ' || die 1 "Failed to insert pre-partition test data"
+
+  sleep 3
+  log "Pre-partition test data inserted"
+}
+
+apply_partition() {
+  log "Applying network partition to ${TARGET_POD}..."
+
+  for peer_ip in "${PEER_IPS[@]}"; do
+    log "Blocking traffic between ${TARGET_POD} and ${peer_ip}"
+    run kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+      iptables -A INPUT -s "${peer_ip}" -j DROP
+    run kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+      iptables -A OUTPUT -d "${peer_ip}" -j DROP
+  done
+
+  PARTITION_APPLIED=true
+  log "Network partition applied"
+}
+
+wait_for_membership_loss() {
+  log "Waiting up to ${DETECTION_TIMEOUT}s for partition detection..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for membership loss detection"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary 2>/dev/null) || true
+
+  # If the target was not the primary, use the current primary to check
+  if [[ -z "${primary}" || "${primary}" == "${TARGET_POD}" ]]; then
+    # Try each non-target pod
+    local pods
+    pods=$(kubectl get pods -n "${NAMESPACE}" \
+      -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+      -o jsonpath='{.items[*].metadata.name}')
+
+    for pod in ${pods}; do
+      if [[ "${pod}" != "${TARGET_POD}" ]]; then
+        primary="${pod}"
+        break
+      fi
+    done
+  fi
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${DETECTION_TIMEOUT}" ]]; do
+    local target_state
+    target_state=$(mongo_eval "${primary}" "
+      const status = rs.status();
+      const member = status.members.find(m => m.name.includes('${TARGET_POD}'));
+      member ? member.stateStr : 'UNKNOWN';
+    " 2>/dev/null || echo "UNKNOWN")
+
+    if [[ "${target_state}" != "SECONDARY" && "${target_state}" != "PRIMARY" ]]; then
+      log "Partitioned member detected as: ${target_state} (after ${elapsed}s)"
+      return 0
+    fi
+
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  log "WARNING: Partitioned member may not have been fully detected within ${DETECTION_TIMEOUT}s"
+}
+
+hold_partition() {
+  log "Maintaining partition for ${PARTITION_DURATION}s..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would hold partition for ${PARTITION_DURATION}s"
+    return 0
+  fi
+
+  # Insert additional data during partition
+  local primary
+  primary=$(find_primary 2>/dev/null) || true
+
+  if [[ -n "${primary}" && "${primary}" != "${TARGET_POD}" ]]; then
+    log "Inserting data during partition..."
+    mongo_eval "${primary}" '
+      const db = db.getSiblingDB("chaos_test");
+      for (let i = 0; i < 50; i++) {
+        db.partition_test.insertOne(
+          {seq: i + 50, phase: "during-partition", ts: new Date()},
+          {writeConcern: {w: 1, wtimeout: 5000}}
+        );
+      }
+    ' || log "WARNING: Some writes during partition may have failed"
+  fi
+
+  sleep "${PARTITION_DURATION}"
+}
+
+heal_partition() {
+  log "Healing network partition on ${TARGET_POD}..."
+
+  for peer_ip in "${PEER_IPS[@]}"; do
+    log "Removing iptables rules for ${peer_ip}"
+    run kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+      iptables -D INPUT -s "${peer_ip}" -j DROP 2>/dev/null || true
+    run kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+      iptables -D OUTPUT -d "${peer_ip}" -j DROP 2>/dev/null || true
+  done
+
+  PARTITION_APPLIED=false
+  log "Network partition healed"
+}
+
+wait_for_rejoin() {
+  log "Waiting up to ${RECOVERY_TIMEOUT}s for member to rejoin..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would wait for member to rejoin"
+    return 0
+  fi
+
+  local check_pod
+  local pods
+  pods=$(kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}')
+
+  for pod in ${pods}; do
+    if [[ "${pod}" != "${TARGET_POD}" ]]; then
+      check_pod="${pod}"
+      break
+    fi
+  done
+
+  local elapsed=0
+
+  while [[ "${elapsed}" -lt "${RECOVERY_TIMEOUT}" ]]; do
+    local target_state
+    target_state=$(mongo_eval "${check_pod}" "
+      const status = rs.status();
+      const member = status.members.find(m => m.name.includes('${TARGET_POD}'));
+      member ? member.stateStr : 'UNKNOWN';
+    " 2>/dev/null || echo "UNKNOWN")
+
+    if [[ "${target_state}" == "SECONDARY" || "${target_state}" == "PRIMARY" ]]; then
+      log "Member rejoined as ${target_state} (after ${elapsed}s)"
+      return 0
+    fi
+
+    log "Member state: ${target_state} (waiting for SECONDARY or PRIMARY)..."
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
+  die 1 "Member did not rejoin within ${RECOVERY_TIMEOUT}s"
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+validate_recovery() {
+  log "Running recovery validation..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would validate recovery"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary) || die 1 "No primary found after partition healing"
+
+  # Check all data is present
+  local total_count
+  total_count=$(mongo_eval "${primary}" \
+    'db.getSiblingDB("chaos_test").partition_test.countDocuments({})') \
+    || die 1 "Failed to get document count"
+
+  if [[ "${total_count}" -lt 50 ]]; then
+    die 1 "Data loss detected: expected at least 50 pre-partition documents, found ${total_count}"
+  fi
+  log "Total documents on primary: ${total_count}"
+
+  # Wait for the target to catch up, then verify its count
+  sleep 5
+  local target_count
+  target_count=$(mongo_eval "${TARGET_POD}" \
+    'db.getSiblingDB("chaos_test").partition_test.countDocuments({})') \
+    || log "WARNING: Could not read from recovered member directly"
+
+  if [[ -n "${target_count}" ]]; then
+    log "Documents on recovered member: ${target_count}"
+    if [[ "${target_count}" -lt "${total_count}" ]]; then
+      log "WARNING: Recovered member still catching up (${target_count}/${total_count})"
+    fi
+  fi
+
+  # Validate majority write succeeds
+  log "Testing majority write concern..."
+  local write_result
+  write_result=$(mongo_eval "${primary}" '
+    try {
+      db.getSiblingDB("chaos_test").partition_test.insertOne(
+        {seq: 999, phase: "post-partition", ts: new Date()},
+        {writeConcern: {w: "majority", wtimeout: 10000}}
+      );
+      "write_ok"
+    } catch(e) {
+      "write_failed: " + e.message
+    }
+  ') || die 1 "Failed to execute majority write test"
+
+  if [[ "${write_result}" != *"write_ok"* ]]; then
+    die 1 "Majority write failed after partition healing: ${write_result}"
+  fi
+  log "Majority write succeeded"
+
+  # Call validate-recovery.sh if available
+  if [[ -x "${SCRIPT_DIR}/validate-recovery.sh" ]]; then
+    log "Running comprehensive recovery validation..."
+    "${SCRIPT_DIR}/validate-recovery.sh" \
+      --namespace "${NAMESPACE}" \
+      --cluster-name "${CLUSTER_NAME}" \
+      --rs-name "${RS_NAME}"
+  fi
+
+  log "All validations passed"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  # Always attempt to heal partition on exit
+  if [[ "${PARTITION_APPLIED}" == "true" ]]; then
+    log "Cleanup: healing partition..."
+    for peer_ip in "${PEER_IPS[@]}"; do
+      kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+        iptables -D INPUT -s "${peer_ip}" -j DROP 2>/dev/null || true
+      kubectl exec -n "${NAMESPACE}" "${TARGET_POD}" -- \
+        iptables -D OUTPUT -d "${peer_ip}" -j DROP 2>/dev/null || true
+    done
+  fi
+
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    log "Cleaning up test data..."
+    local primary
+    primary=$(find_primary 2>/dev/null) || true
+    if [[ -n "${primary}" ]]; then
+      mongo_eval "${primary}" \
+        'db.getSiblingDB("chaos_test").partition_test.drop()' &>/dev/null || true
+    fi
+  fi
+}
+
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  log "=== Network Partition Chaos Test ==="
+  log "Namespace:  ${NAMESPACE}"
+  log "Cluster:    ${CLUSTER_NAME}"
+  log "RS Name:    ${RS_NAME}"
+  log "Duration:   ${PARTITION_DURATION}s"
+  log "Dry Run:    ${DRY_RUN}"
+
+  check_preconditions
+  select_target
+  insert_test_data
+  apply_partition
+  wait_for_membership_loss
+  hold_partition
+  heal_partition
+  wait_for_rejoin
+  validate_recovery
+
+  log "=== Network Partition Chaos Test PASSED ==="
+}
+
+main

--- a/tests/chaos/validate-recovery.sh
+++ b/tests/chaos/validate-recovery.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# validate-recovery.sh - Generic recovery validation for MongoDB replica sets.
+# Checks member health, primary count, replication lag, write availability,
+# and backup agent status. Can be run standalone or called from other scripts.
+# ---------------------------------------------------------------------------
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# Defaults
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+RS_NAME="${RS_NAME:-rs0}"
+MAX_LAG=10
+DRY_RUN=false
+
+# Counters
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+usage() {
+  cat <<HELP
+Usage: ${SCRIPT_NAME} [OPTIONS]
+
+Validate the health and recovery state of a MongoDB replica set. Performs
+the following checks:
+
+  - All RS members are in a healthy state (PRIMARY or SECONDARY)
+  - Exactly one PRIMARY exists
+  - Replication lag is below the specified threshold
+  - Majority write concern succeeds
+  - PBM backup agent is running and healthy
+
+This script can be run standalone or called from other chaos test scripts.
+
+Options:
+  --namespace NAME        Kubernetes namespace (env: NAMESPACE, default: mongodb)
+  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --rs-name NAME          Replica set name (env: RS_NAME, default: rs0)
+  --max-lag SEC           Maximum acceptable replication lag in seconds (default: 10)
+  --dry-run               Print checks without executing
+  --help                  Show this help message
+
+Environment variables:
+  NAMESPACE      Kubernetes namespace
+  CLUSTER_NAME   Percona cluster name
+  RS_NAME        Replica set name
+
+Exit codes:
+  0  All checks passed
+  1  One or more checks failed
+  2  Usage error
+  3  Precondition not met
+HELP
+}
+
+run() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] $*"
+  else
+    "$@"
+  fi
+}
+
+die() {
+  local code="$1"
+  shift
+  log "ERROR: $*" >&2
+  exit "${code}"
+}
+
+check_pass() {
+  CHECKS_PASSED=$((CHECKS_PASSED + 1))
+  log "PASS: $*"
+}
+
+check_fail() {
+  CHECKS_FAILED=$((CHECKS_FAILED + 1))
+  log "FAIL: $*"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      [[ -n "${2:-}" ]] || die 2 "--namespace requires a value"
+      NAMESPACE="$2"; shift 2 ;;
+    --cluster-name)
+      [[ -n "${2:-}" ]] || die 2 "--cluster-name requires a value"
+      CLUSTER_NAME="$2"; shift 2 ;;
+    --rs-name)
+      [[ -n "${2:-}" ]] || die 2 "--rs-name requires a value"
+      RS_NAME="$2"; shift 2 ;;
+    --max-lag)
+      [[ -n "${2:-}" ]] || die 2 "--max-lag requires a value"
+      MAX_LAG="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    --help)
+      usage; exit 0 ;;
+    *)
+      die 2 "Unknown option: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Precondition checks
+# ---------------------------------------------------------------------------
+
+check_preconditions() {
+  log "Checking preconditions..."
+
+  if ! command -v kubectl &>/dev/null; then
+    die 3 "kubectl is not installed or not in PATH"
+  fi
+
+  if ! kubectl get namespace "${NAMESPACE}" &>/dev/null; then
+    die 3 "Namespace '${NAMESPACE}' does not exist"
+  fi
+
+  log "Preconditions satisfied"
+}
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+mongo_eval() {
+  local pod="$1"
+  shift
+  kubectl exec -n "${NAMESPACE}" "${pod}" -- \
+    mongosh --quiet --eval "$@" 2>/dev/null
+}
+
+get_mongod_pods() {
+  kubectl get pods -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CLUSTER_NAME},app.kubernetes.io/component=mongod" \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null
+}
+
+find_primary() {
+  local pods
+  pods=$(get_mongod_pods)
+
+  for pod in ${pods}; do
+    local is_master
+    is_master=$(mongo_eval "${pod}" 'db.isMaster().ismaster' 2>/dev/null || echo "false")
+    if [[ "${is_master}" == "true" ]]; then
+      echo "${pod}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Validation checks
+# ---------------------------------------------------------------------------
+
+check_all_members_healthy() {
+  log "Check: All RS members are in a healthy state..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would check all members healthy"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary 2>/dev/null) || {
+    check_fail "Cannot find any primary to query RS status"
+    return 1
+  }
+
+  local unhealthy
+  unhealthy=$(mongo_eval "${primary}" '
+    const status = rs.status();
+    const bad = status.members.filter(m =>
+      m.stateStr !== "PRIMARY" &&
+      m.stateStr !== "SECONDARY" &&
+      m.stateStr !== "ARBITER"
+    );
+    JSON.stringify(bad.map(m => ({name: m.name, state: m.stateStr})));
+  ') || {
+    check_fail "Failed to query RS member states"
+    return 1
+  }
+
+  if [[ "${unhealthy}" == "[]" ]]; then
+    check_pass "All RS members are healthy"
+  else
+    check_fail "Unhealthy members found: ${unhealthy}"
+  fi
+}
+
+check_single_primary() {
+  log "Check: Exactly one PRIMARY exists..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would check single primary"
+    return 0
+  fi
+
+  local any_pod
+  any_pod=$(get_mongod_pods | awk '{print $1}')
+  if [[ -z "${any_pod}" ]]; then
+    check_fail "No mongod pods found"
+    return 1
+  fi
+
+  local primary_count
+  primary_count=$(mongo_eval "${any_pod}" '
+    const status = rs.status();
+    status.members.filter(m => m.stateStr === "PRIMARY").length;
+  ') || {
+    check_fail "Failed to query primary count"
+    return 1
+  }
+
+  if [[ "${primary_count}" == "1" ]]; then
+    check_pass "Exactly 1 PRIMARY exists"
+  else
+    check_fail "Expected 1 PRIMARY, found ${primary_count}"
+  fi
+}
+
+check_replication_lag() {
+  log "Check: Replication lag < ${MAX_LAG}s on all secondaries..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would check replication lag"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary 2>/dev/null) || {
+    check_fail "Cannot find primary to check replication lag"
+    return 1
+  }
+
+  local lag_result
+  lag_result=$(mongo_eval "${primary}" "
+    const status = rs.status();
+    const primary = status.members.find(m => m.stateStr === 'PRIMARY');
+    const results = status.members
+      .filter(m => m.stateStr === 'SECONDARY')
+      .map(m => ({
+        name: m.name,
+        lagSeconds: Math.round((primary.optimeDate - m.optimeDate) / 1000)
+      }));
+    JSON.stringify(results);
+  ") || {
+    check_fail "Failed to query replication lag"
+    return 1
+  }
+
+  local has_excessive_lag
+  has_excessive_lag=$(mongo_eval "${primary}" "
+    const status = rs.status();
+    const primary = status.members.find(m => m.stateStr === 'PRIMARY');
+    const lagging = status.members.filter(m =>
+      m.stateStr === 'SECONDARY' &&
+      Math.round((primary.optimeDate - m.optimeDate) / 1000) > ${MAX_LAG}
+    );
+    lagging.length;
+  ") || {
+    check_fail "Failed to evaluate lag threshold"
+    return 1
+  }
+
+  if [[ "${has_excessive_lag}" == "0" ]]; then
+    check_pass "Replication lag within threshold (${MAX_LAG}s): ${lag_result}"
+  else
+    check_fail "Replication lag exceeds ${MAX_LAG}s: ${lag_result}"
+  fi
+}
+
+check_majority_write() {
+  log "Check: Majority write concern succeeds..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would check majority write"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary 2>/dev/null) || {
+    check_fail "Cannot find primary for write test"
+    return 1
+  }
+
+  local write_result
+  write_result=$(mongo_eval "${primary}" '
+    try {
+      db.getSiblingDB("chaos_test").recovery_validation.insertOne(
+        {test: "validate-recovery", ts: new Date()},
+        {writeConcern: {w: "majority", wtimeout: 10000}}
+      );
+      "write_ok"
+    } catch(e) {
+      "write_failed: " + e.message
+    }
+  ') || {
+    check_fail "Failed to execute majority write test"
+    return 1
+  }
+
+  if [[ "${write_result}" == *"write_ok"* ]]; then
+    check_pass "Majority write succeeded"
+    # Clean up test document
+    mongo_eval "${primary}" \
+      'db.getSiblingDB("chaos_test").recovery_validation.drop()' &>/dev/null || true
+  else
+    check_fail "Majority write failed: ${write_result}"
+  fi
+}
+
+check_backup_agent() {
+  log "Check: PBM backup agent is healthy..."
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    log "[DRY-RUN] Would check backup agent"
+    return 0
+  fi
+
+  local primary
+  primary=$(find_primary 2>/dev/null) || {
+    check_fail "Cannot find primary to check backup agent"
+    return 1
+  }
+
+  # Check if PBM status can be retrieved from the backup agent container
+  local pbm_status
+  pbm_status=$(kubectl exec -n "${NAMESPACE}" "${primary}" -c backup-agent -- \
+    pbm status 2>/dev/null) || {
+    # Backup agent container may not exist or PBM may not be configured
+    log "INFO: Backup agent check skipped (container or PBM not available)"
+    return 0
+  }
+
+  if echo "${pbm_status}" | grep -qi "error"; then
+    check_fail "PBM agent reports errors: $(echo "${pbm_status}" | head -5)"
+  else
+    check_pass "PBM backup agent is healthy"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  log "=== MongoDB Replica Set Recovery Validation ==="
+  log "Namespace:  ${NAMESPACE}"
+  log "Cluster:    ${CLUSTER_NAME}"
+  log "RS Name:    ${RS_NAME}"
+  log "Max Lag:    ${MAX_LAG}s"
+  log "Dry Run:    ${DRY_RUN}"
+
+  check_preconditions
+
+  check_all_members_healthy
+  check_single_primary
+  check_replication_lag
+  check_majority_write
+  check_backup_agent
+
+  log "---"
+  log "Results: ${CHECKS_PASSED} passed, ${CHECKS_FAILED} failed"
+
+  if [[ "${CHECKS_FAILED}" -gt 0 ]]; then
+    log "=== Recovery Validation FAILED ==="
+    exit 1
+  fi
+
+  log "=== Recovery Validation PASSED ==="
+}
+
+main


### PR DESCRIPTION
## Summary

- Adds `tests/chaos/kill-primary.sh` - primary pod deletion with election validation (< 60s)
- Adds `tests/chaos/delete-pv.sh` - PVC deletion with initial sync recovery validation
- Adds `tests/chaos/network-partition.sh` - iptables-based network isolation with automatic healing
- Adds `tests/chaos/validate-recovery.sh` - generic 5-point recovery check (members, primary, lag, write, backup)
- All scripts support `--help`, `--dry-run`, and consistent logging

## Test plan

- [ ] `shellcheck tests/chaos/*.sh`
- [ ] Run `tests/chaos/kill-primary.sh --dry-run` to verify command output
- [ ] Run `tests/chaos/validate-recovery.sh` standalone on a healthy cluster

Closes #44, #45, #46