### PR TITLE
fix(tests): resolve SC2155 shellcheck warnings

### DIFF
--- a/backup/restore/restore-full.sh
+++ b/backup/restore/restore-full.sh
@@ -113,7 +113,8 @@ perform_restore() {
   log "Starting full restore from backup '${BACKUP_NAME}'..."
 
   # Create restore CR
-  local restore_name="restore-$(date +%Y%m%d-%H%M%S)"
+  local restore_name
+  restore_name="restore-$(date +%Y%m%d-%H%M%S)"
 
   run kubectl apply -f - <<EOF
 apiVersion: psmdb.percona.com/v1

--- a/backup/restore/restore-pitr.sh
+++ b/backup/restore/restore-pitr.sh
@@ -116,7 +116,8 @@ check_pitr_available() {
 perform_pitr_restore() {
   log "Starting Point-in-Time Recovery to ${TARGET_TIME}..."
 
-  local restore_name="pitr-restore-$(date +%Y%m%d-%H%M%S)"
+  local restore_name
+  restore_name="pitr-restore-$(date +%Y%m%d-%H%M%S)"
 
   run kubectl apply -f - <<EOF
 apiVersion: psmdb.percona.com/v1

--- a/tests/ci/backup-restore-ephemeral.sh
+++ b/tests/ci/backup-restore-ephemeral.sh
@@ -106,7 +106,8 @@ record_pre_backup_state() {
 
 trigger_backup() {
   log "Step 3: Triggering manual backup..."
-  local backup_name="ci-backup-$(date +%Y%m%d-%H%M%S)"
+  local backup_name
+  backup_name="ci-backup-$(date +%Y%m%d-%H%M%S)"
 
   run kubectl apply -f - <<EOF
 apiVersion: psmdb.percona.com/v1


### PR DESCRIPTION
## Summary

- Split `local` declaration from command substitution assignment in 3 scripts
- Fixes SC2155: combined `local` + `$()` masks the return value
- Files fixed: `restore-full.sh`, `restore-pitr.sh`, `backup-restore-ephemeral.sh`

## Test plan

- [ ] CI lint workflow passes (shellcheck green)