### PR TITLE
fix(scripts): pin kind to v1.29.12 and add auth to bootstrap and seed

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,7 +17,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Configuration
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-mongodb-dbaas}"
-KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.28.13}"
+KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.29.12}"
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-mongodb-operator}"
 MONGODB_NAMESPACE="${MONGODB_NAMESPACE:-mongodb}"
 HELM_REPO_NAME="percona"
@@ -143,8 +143,25 @@ deploy_mongodb_cluster() {
 
   log "Deploying MongoDB replica set..."
 
-  # Create namespace and apply replica set resources
-  run kubectl create namespace "${MONGODB_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+  # Create namespace
+  kubectl create namespace "${MONGODB_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+  # Create users secret required by the PSMDB CR
+  kubectl create secret generic mongodb-rs-secrets \
+    -n "${MONGODB_NAMESPACE}" \
+    --from-literal=MONGODB_DATABASE_ADMIN_USER=databaseAdmin \
+    --from-literal=MONGODB_DATABASE_ADMIN_PASSWORD=databaseAdmin123 \
+    --from-literal=MONGODB_CLUSTER_ADMIN_USER=clusterAdmin \
+    --from-literal=MONGODB_CLUSTER_ADMIN_PASSWORD=clusterAdmin123 \
+    --from-literal=MONGODB_USER_ADMIN_USER=userAdmin \
+    --from-literal=MONGODB_USER_ADMIN_PASSWORD=userAdmin123 \
+    --from-literal=MONGODB_CLUSTER_MONITOR_USER=clusterMonitor \
+    --from-literal=MONGODB_CLUSTER_MONITOR_PASSWORD=clusterMonitor123 \
+    --from-literal=MONGODB_BACKUP_USER=backup \
+    --from-literal=MONGODB_BACKUP_PASSWORD=backup123 \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  # Apply replica set resources
   run kubectl apply -k "${PROJECT_ROOT}/clusters/replicaset/"
 
   log "Waiting for replica set pods to become ready..."

--- a/scripts/seed-data.sh
+++ b/scripts/seed-data.sh
@@ -34,10 +34,33 @@ usage() {
   exit 0
 }
 
+get_admin_credentials() {
+  local secret_name="${CLUSTER_NAME}-secrets"
+  local user pass
+  user=$(kubectl get secret "${secret_name}" -n "${NAMESPACE}" \
+    -o jsonpath='{.data.MONGODB_DATABASE_ADMIN_USER}' 2>/dev/null | base64 -d)
+  pass=$(kubectl get secret "${secret_name}" -n "${NAMESPACE}" \
+    -o jsonpath='{.data.MONGODB_DATABASE_ADMIN_PASSWORD}' 2>/dev/null | base64 -d)
+  if [ -n "${user}" ] && [ -n "${pass}" ]; then
+    echo "${user}:${pass}"
+  fi
+}
+
 run_mongosh() {
   local pod="${CLUSTER_NAME}-${RS_NAME}-0"
-  kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
-    mongosh --quiet --eval "$1" 2>/dev/null
+  local creds
+  creds=$(get_admin_credentials)
+  if [ -n "${creds}" ]; then
+    local user="${creds%%:*}"
+    local pass="${creds#*:}"
+    kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
+      mongosh --quiet \
+      -u "${user}" -p "${pass}" --authenticationDatabase admin \
+      --eval "$1" 2>/dev/null
+  else
+    kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
+      mongosh --quiet --eval "$1" 2>/dev/null
+  fi
 }
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- 📌 Pin kind node image to `v1.29.12` for Percona Operator compatibility (was `v1.28.13`)
- 🔐 Create `mongodb-rs-secrets` Secret before CR deployment in `bootstrap.sh`
- 🔑 Add credential-based authentication to `seed-data.sh` (reads from K8s Secret)

## Test plan
- [x] `make teardown && make bootstrap` completes successfully
- [x] `make seed-data` inserts 260 documents with auth
- [x] `bats tests/bats/test_replicaset_health.bats` passes 8/8