### PR TITLE
feat(chaos): align cluster naming and add demo wrapper with annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ test-chaos: ## Run chaos engineering scenarios
 	@echo "Running chaos tests..."
 	@for script in tests/chaos/*.sh; do bash "$$script"; done
 
+.PHONY: demo-chaos
+demo-chaos: ## Run chaos demo (kill primary + failover + recovery)
+	@./scripts/demo-chaos.sh
+
 .PHONY: test-backup
 test-backup: ## Run backup/restore validation cycle
 	@echo "Running backup validation..."

--- a/scripts/demo-chaos.sh
+++ b/scripts/demo-chaos.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Configuration
 NAMESPACE="${NAMESPACE:-mongodb}"
@@ -245,6 +244,8 @@ echo ""
 log "========================================="
 log "  Chaos Demo Results"
 log "========================================="
+log "  Old primary:       ${PRIMARY_POD}"
+log "  New primary:       ${NEW_PRIMARY:-N/A}"
 log "  Failover time:     ${FAILOVER_DURATION:-N/A}s"
 log "  Recovery time:     ${RECOVERY_DURATION:-N/A}s"
 log "  Total duration:    ${TOTAL_DURATION}s"

--- a/scripts/demo-chaos.sh
+++ b/scripts/demo-chaos.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# demo-chaos.sh - Full chaos engineering demo: kill primary, validate failover,
+# verify recovery, and post Grafana annotations for visual timeline.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Configuration
+NAMESPACE="${NAMESPACE:-mongodb}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
+RS_NAME="${RS_NAME:-rs0}"
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
+SKIP_ANNOTATIONS="${SKIP_ANNOTATIONS:-false}"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+annotate() {
+  if [ "${SKIP_ANNOTATIONS}" = "true" ]; then
+    return 0
+  fi
+  "${SCRIPT_DIR}/grafana-annotate.sh" \
+    --url "${GRAFANA_URL}" \
+    --tags "chaos,demo" \
+    "$1" 2>/dev/null || true
+}
+
+get_admin_credentials() {
+  local secret_name="${CLUSTER_NAME}-secrets"
+  local user pass
+  user=$(kubectl get secret "${secret_name}" -n "${NAMESPACE}" \
+    -o jsonpath='{.data.MONGODB_DATABASE_ADMIN_USER}' 2>/dev/null | base64 -d)
+  pass=$(kubectl get secret "${secret_name}" -n "${NAMESPACE}" \
+    -o jsonpath='{.data.MONGODB_DATABASE_ADMIN_PASSWORD}' 2>/dev/null | base64 -d)
+  if [ -n "${user}" ] && [ -n "${pass}" ]; then
+    echo "${user}:${pass}"
+  fi
+}
+
+run_mongosh() {
+  local pod="${CLUSTER_NAME}-${RS_NAME}-0"
+  local creds
+  creds=$(get_admin_credentials)
+  if [ -n "${creds}" ]; then
+    local user="${creds%%:*}"
+    local pass="${creds#*:}"
+    kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
+      mongosh --quiet \
+      -u "${user}" -p "${pass}" --authenticationDatabase admin \
+      --eval "$1" 2>/dev/null
+  else
+    kubectl exec "${pod}" -n "${NAMESPACE}" -c mongod -- \
+      mongosh --quiet --eval "$1" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Pre-chaos health check
+# ---------------------------------------------------------------------------
+log "========================================="
+log "  MongoDB Chaos Engineering Demo"
+log "========================================="
+echo ""
+
+log "Phase 1: Pre-chaos health check"
+log "-----------------------------------------"
+
+# Find current primary
+PRIMARY_POD=""
+for i in 0 1 2; do
+  POD="${CLUSTER_NAME}-${RS_NAME}-${i}"
+  STATE=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c mongod -- \
+    mongosh --quiet \
+    -u "$(get_admin_credentials | cut -d: -f1)" \
+    -p "$(get_admin_credentials | cut -d: -f2)" \
+    --authenticationDatabase admin \
+    --eval "rs.isMaster().ismaster" 2>/dev/null || echo "false")
+  if [ "${STATE}" = "true" ]; then
+    PRIMARY_POD="${POD}"
+    log "  Current PRIMARY: ${POD}"
+    break
+  fi
+done
+
+if [ -z "${PRIMARY_POD}" ]; then
+  log "ERROR: No primary found. Aborting."
+  exit 1
+fi
+
+# Show current RS status
+log "  Replica set members:"
+for i in 0 1 2; do
+  POD="${CLUSTER_NAME}-${RS_NAME}-${i}"
+  READY=$(kubectl get pod "${POD}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+  log "    ${POD}: Ready=${READY}"
+done
+
+DEMO_START=$(date +%s)
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 2: Kill primary
+# ---------------------------------------------------------------------------
+log "Phase 2: Killing primary pod"
+log "-----------------------------------------"
+
+annotate "CHAOS START: Killing primary ${PRIMARY_POD}"
+KILL_TIME=$(date +%s)
+
+log "  Deleting pod: ${PRIMARY_POD}"
+kubectl delete pod "${PRIMARY_POD}" -n "${NAMESPACE}" --grace-period=0 --force 2>/dev/null
+log "  Primary pod deleted at $(date -u +%H:%M:%S)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 3: Wait for failover
+# ---------------------------------------------------------------------------
+log "Phase 3: Waiting for automatic failover"
+log "-----------------------------------------"
+
+FAILOVER_DETECTED=false
+NEW_PRIMARY=""
+for attempt in $(seq 1 30); do
+  for i in 0 1 2; do
+    POD="${CLUSTER_NAME}-${RS_NAME}-${i}"
+    if [ "${POD}" = "${PRIMARY_POD}" ]; then
+      continue
+    fi
+    STATE=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c mongod -- \
+      mongosh --quiet \
+      -u "$(get_admin_credentials | cut -d: -f1)" \
+      -p "$(get_admin_credentials | cut -d: -f2)" \
+      --authenticationDatabase admin \
+      --eval "rs.isMaster().ismaster" 2>/dev/null || echo "false")
+    if [ "${STATE}" = "true" ]; then
+      FAILOVER_TIME=$(date +%s)
+      FAILOVER_DURATION=$((FAILOVER_TIME - KILL_TIME))
+      NEW_PRIMARY="${POD}"
+      FAILOVER_DETECTED=true
+      log "  New PRIMARY elected: ${POD} (failover in ${FAILOVER_DURATION}s)"
+      annotate "FAILOVER: New primary ${POD} elected in ${FAILOVER_DURATION}s"
+      break 2
+    fi
+  done
+  log "  Waiting for election... (attempt ${attempt}/30)"
+  sleep 2
+done
+
+if [ "${FAILOVER_DETECTED}" = "false" ]; then
+  log "ERROR: Failover not detected within 60s"
+  annotate "CHAOS FAILED: No failover detected"
+  exit 1
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 4: Wait for pod recovery
+# ---------------------------------------------------------------------------
+log "Phase 4: Waiting for killed pod to recover"
+log "-----------------------------------------"
+
+RECOVERY_DETECTED=false
+for attempt in $(seq 1 60); do
+  READY=$(kubectl get pod "${PRIMARY_POD}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+  if [ "${READY}" = "True" ]; then
+    RECOVERY_TIME=$(date +%s)
+    RECOVERY_DURATION=$((RECOVERY_TIME - KILL_TIME))
+    RECOVERY_DETECTED=true
+    log "  Pod ${PRIMARY_POD} recovered (total recovery: ${RECOVERY_DURATION}s)"
+    annotate "RECOVERY: ${PRIMARY_POD} back online in ${RECOVERY_DURATION}s"
+    break
+  fi
+  log "  Pod not ready yet... (attempt ${attempt}/60)"
+  sleep 5
+done
+
+if [ "${RECOVERY_DETECTED}" = "false" ]; then
+  log "WARNING: Pod did not recover within 300s"
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 5: Post-chaos validation
+# ---------------------------------------------------------------------------
+log "Phase 5: Post-chaos validation"
+log "-----------------------------------------"
+
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+
+# Check all 3 pods ready
+READY_COUNT=$(kubectl get pods -n "${NAMESPACE}" \
+  -l "app.kubernetes.io/instance=${CLUSTER_NAME}" \
+  -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | tr ' ' '\n' | grep -c "True" || echo "0")
+if [ "${READY_COUNT}" -ge 3 ]; then
+  log "  [PASS] All 3 pods are ready"
+  CHECKS_PASSED=$((CHECKS_PASSED + 1))
+else
+  log "  [FAIL] Only ${READY_COUNT}/3 pods ready"
+  CHECKS_FAILED=$((CHECKS_FAILED + 1))
+fi
+
+# Check exactly 1 primary
+PRIMARY_COUNT=$(run_mongosh "rs.status().members.filter(m => m.stateStr === 'PRIMARY').length" || echo "0")
+if [ "${PRIMARY_COUNT}" = "1" ]; then
+  log "  [PASS] Exactly 1 PRIMARY"
+  CHECKS_PASSED=$((CHECKS_PASSED + 1))
+else
+  log "  [FAIL] ${PRIMARY_COUNT} primaries detected"
+  CHECKS_FAILED=$((CHECKS_FAILED + 1))
+fi
+
+# Check write concern majority
+WRITE_RESULT=$(run_mongosh "db.getSiblingDB('chaos_test').recovery.insertOne({ts: new Date(), test: 'chaos-demo'}, {writeConcern: {w: 'majority', wtimeout: 5000}}).acknowledged" || echo "false")
+if [ "${WRITE_RESULT}" = "true" ]; then
+  log "  [PASS] Write concern majority succeeds"
+  CHECKS_PASSED=$((CHECKS_PASSED + 1))
+else
+  log "  [FAIL] Write concern majority failed"
+  CHECKS_FAILED=$((CHECKS_FAILED + 1))
+fi
+
+# Check PSMDB status
+PSMDB_STATE=$(kubectl get psmdb "${CLUSTER_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
+if [ "${PSMDB_STATE}" = "ready" ]; then
+  log "  [PASS] PSMDB cluster state: ready"
+  CHECKS_PASSED=$((CHECKS_PASSED + 1))
+else
+  log "  [FAIL] PSMDB cluster state: ${PSMDB_STATE}"
+  CHECKS_FAILED=$((CHECKS_FAILED + 1))
+fi
+
+DEMO_END=$(date +%s)
+TOTAL_DURATION=$((DEMO_END - DEMO_START))
+
+echo ""
+log "========================================="
+log "  Chaos Demo Results"
+log "========================================="
+log "  Failover time:     ${FAILOVER_DURATION:-N/A}s"
+log "  Recovery time:     ${RECOVERY_DURATION:-N/A}s"
+log "  Total duration:    ${TOTAL_DURATION}s"
+log "  Checks passed:     ${CHECKS_PASSED}/4"
+log "  Checks failed:     ${CHECKS_FAILED}/4"
+log "========================================="
+
+annotate "CHAOS COMPLETE: ${CHECKS_PASSED}/4 checks passed, failover in ${FAILOVER_DURATION:-N/A}s"
+
+if [ "${CHECKS_FAILED}" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/grafana-annotate.sh
+++ b/scripts/grafana-annotate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# grafana-annotate.sh - Post annotations to Grafana for chaos events timeline.
+# ---------------------------------------------------------------------------
+
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
+GRAFANA_USER="${GRAFANA_USER:-admin}"
+GRAFANA_PASS="${GRAFANA_PASS:-admin}"
+
+usage() {
+  cat <<HELP
+Usage: $(basename "$0") [OPTIONS] TEXT
+
+Post an annotation to Grafana for timeline visualization.
+
+Options:
+  --url URL       Grafana URL (env: GRAFANA_URL, default: http://localhost:3000)
+  --user USER     Grafana admin user (env: GRAFANA_USER, default: admin)
+  --pass PASS     Grafana admin password (env: GRAFANA_PASS, default: admin)
+  --tags TAGS     Comma-separated tags (default: chaos)
+  --dashboard UID Dashboard UID to annotate (optional, default: global)
+  -h, --help      Show this help
+
+Examples:
+  $(basename "$0") "Chaos: primary killed"
+  $(basename "$0") --tags "chaos,failover" "Primary failover started"
+HELP
+  exit 0
+}
+
+TAGS="chaos"
+DASHBOARD_UID=""
+TEXT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url) GRAFANA_URL="$2"; shift 2 ;;
+    --user) GRAFANA_USER="$2"; shift 2 ;;
+    --pass) GRAFANA_PASS="$2"; shift 2 ;;
+    --tags) TAGS="$2"; shift 2 ;;
+    --dashboard) DASHBOARD_UID="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) TEXT="$1"; shift ;;
+  esac
+done
+
+if [ -z "${TEXT}" ]; then
+  echo "Error: annotation text is required" >&2
+  usage
+fi
+
+# Convert comma-separated tags to JSON array
+TAGS_JSON=$(echo "${TAGS}" | tr ',' '\n' | sed 's/^/"/;s/$/"/' | paste -sd ',' -)
+
+PAYLOAD="{\"text\":\"${TEXT}\",\"tags\":[${TAGS_JSON}]"
+if [ -n "${DASHBOARD_UID}" ]; then
+  PAYLOAD="${PAYLOAD},\"dashboardUID\":\"${DASHBOARD_UID}\""
+fi
+PAYLOAD="${PAYLOAD}}"
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST "${GRAFANA_URL}/api/annotations" \
+  -H "Content-Type: application/json" \
+  -u "${GRAFANA_USER}:${GRAFANA_PASS}" \
+  -d "${PAYLOAD}" 2>/dev/null) || true
+
+HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
+BODY=$(echo "${RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ]; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Annotation posted: ${TEXT}"
+else
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] WARNING: Failed to post annotation (HTTP ${HTTP_CODE}): ${BODY}" >&2
+fi

--- a/tests/chaos/delete-pv.sh
+++ b/tests/chaos/delete-pv.sh
@@ -11,7 +11,7 @@ SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
 # Defaults
 NAMESPACE="${NAMESPACE:-mongodb}"
-CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
 RS_NAME="${RS_NAME:-rs0}"
 DRY_RUN=false
 RECOVERY_TIMEOUT=300
@@ -34,7 +34,7 @@ that the member recovers via initial sync with no data loss.
 
 Options:
   --namespace NAME         Kubernetes namespace (env: NAMESPACE, default: mongodb)
-  --cluster-name NAME      Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --cluster-name NAME      Percona cluster name (env: CLUSTER_NAME, default: mongodb-rs)
   --rs-name NAME           Replica set name (env: RS_NAME, default: rs0)
   --recovery-timeout SEC   Max seconds to wait for pod rescheduling (default: 300)
   --sync-timeout SEC       Max seconds to wait for initial sync (default: 600)

--- a/tests/chaos/kill-primary.sh
+++ b/tests/chaos/kill-primary.sh
@@ -11,7 +11,7 @@ SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
 # Defaults
 NAMESPACE="${NAMESPACE:-mongodb}"
-CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
 RS_NAME="${RS_NAME:-rs0}"
 DRY_RUN=false
 ELECTION_TIMEOUT=60
@@ -33,7 +33,7 @@ Simulate a MongoDB primary pod failure and validate automatic recovery.
 
 Options:
   --namespace NAME        Kubernetes namespace (env: NAMESPACE, default: mongodb)
-  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: mongodb-rs)
   --rs-name NAME          Replica set name (env: RS_NAME, default: rs0)
   --election-timeout SEC  Max seconds to wait for new primary (default: 60)
   --recovery-timeout SEC  Max seconds to wait for old pod recovery (default: 120)

--- a/tests/chaos/network-partition.sh
+++ b/tests/chaos/network-partition.sh
@@ -11,7 +11,7 @@ SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
 # Defaults
 NAMESPACE="${NAMESPACE:-mongodb}"
-CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
 RS_NAME="${RS_NAME:-rs0}"
 DRY_RUN=false
 PARTITION_DURATION=30
@@ -44,7 +44,7 @@ operator pods typically include iptables in their container image.
 
 Options:
   --namespace NAME            Kubernetes namespace (env: NAMESPACE, default: mongodb)
-  --cluster-name NAME         Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --cluster-name NAME         Percona cluster name (env: CLUSTER_NAME, default: mongodb-rs)
   --rs-name NAME              Replica set name (env: RS_NAME, default: rs0)
   --partition-duration SEC    How long to maintain the partition (default: 30)
   --detection-timeout SEC     Max seconds to detect membership loss (default: 60)

--- a/tests/chaos/validate-recovery.sh
+++ b/tests/chaos/validate-recovery.sh
@@ -11,7 +11,7 @@ SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
 # Defaults
 NAMESPACE="${NAMESPACE:-mongodb}"
-CLUSTER_NAME="${CLUSTER_NAME:-my-cluster}"
+CLUSTER_NAME="${CLUSTER_NAME:-mongodb-rs}"
 RS_NAME="${RS_NAME:-rs0}"
 MAX_LAG=10
 DRY_RUN=false
@@ -45,7 +45,7 @@ This script can be run standalone or called from other chaos test scripts.
 
 Options:
   --namespace NAME        Kubernetes namespace (env: NAMESPACE, default: mongodb)
-  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: my-cluster)
+  --cluster-name NAME     Percona cluster name (env: CLUSTER_NAME, default: mongodb-rs)
   --rs-name NAME          Replica set name (env: RS_NAME, default: rs0)
   --max-lag SEC           Maximum acceptable replication lag in seconds (default: 10)
   --dry-run               Print checks without executing


### PR DESCRIPTION
## Summary
- 🔧 Update `CLUSTER_NAME` default from `my-cluster` to `mongodb-rs` in all 4 chaos scripts
- 📊 Add `scripts/grafana-annotate.sh` for posting timeline annotations to Grafana
- 🎯 Add `scripts/demo-chaos.sh`: kill primary -> validate failover -> verify recovery
- 🛠️ Add `make demo-chaos` Makefile target

## Test plan
- [ ] `make demo-chaos` runs full chaos cycle with structured output
- [ ] Grafana annotations visible on dashboard timeline (when observability deployed)
- [ ] All 4 post-chaos validation checks pass

Closes #117, closes #118