### PR TITLE
feat(terraform): add IaC layer with kind provisioning and reusable modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tfstate.backup
 .terraform/
 .terraform.lock.hcl
+terraform.tfvars
 
 # Certificates & Keys
 *.pem

--- a/docs/guides/terraform-provisioning.md
+++ b/docs/guides/terraform-provisioning.md
@@ -1,0 +1,94 @@
+# 🏗️ Terraform Provisioning Guide
+
+## 📋 Overview
+
+The platform supports Infrastructure as Code (IaC) provisioning via Terraform. The module structure enables identical deployment patterns across local development (kind) and cloud production (EKS) environments.
+
+## 📁 Directory Structure
+
+```
+terraform/
+├── environments/
+│   ├── kind/              # Local development cluster
+│   │   ├── main.tf        # Kind cluster + modules
+│   │   ├── variables.tf   # Configurable parameters
+│   │   ├── outputs.tf     # Cluster info outputs
+│   │   └── versions.tf    # Provider requirements
+│   └── eks/               # AWS EKS reference skeleton
+│       ├── main.tf        # VPC + EKS + modules (commented)
+│       └── README.md
+└── modules/
+    ├── percona-operator/  # Percona Operator Helm deployment
+    │   ├── main.tf
+    │   ├── variables.tf
+    │   └── outputs.tf
+    └── observability/     # kube-prometheus-stack deployment
+        ├── main.tf
+        ├── variables.tf
+        └── outputs.tf
+```
+
+## 🚀 Quick Start (kind)
+
+```bash
+cd terraform/environments/kind
+
+# Initialize providers
+terraform init
+
+# Review the execution plan
+terraform plan
+
+# Provision the cluster
+terraform apply
+
+# View outputs
+terraform output
+```
+
+## ⚙️ Configuration
+
+Copy the example variables file and customize:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `cluster_name` | `mongodb-dbaas` | Kind cluster name |
+| `kubernetes_version` | `v1.29.12` | K8s version |
+| `worker_count` | `3` | Number of worker nodes |
+| `deploy_observability` | `true` | Deploy kube-prometheus-stack |
+| `operator_chart_version` | `1.22.0` | Percona Operator version |
+
+## 🔄 Module Reuse
+
+Both environments reuse the same modules:
+
+```hcl
+# kind environment
+module "percona_operator" {
+  source = "../../modules/percona-operator"
+  # ...
+}
+
+# EKS environment (same module, different config)
+module "percona_operator" {
+  source = "../../modules/percona-operator"
+  # ...
+}
+```
+
+## 🗑️ Teardown
+
+```bash
+terraform destroy
+```
+
+## 🔐 State Management
+
+- **Local (kind)**: State stored locally in `terraform.tfstate`
+- **Production (EKS)**: State stored in S3 with DynamoDB locking
+
+Add `.terraform/` and `*.tfstate*` to `.gitignore` to avoid committing sensitive state files.

--- a/terraform/environments/eks/README.md
+++ b/terraform/environments/eks/README.md
@@ -1,0 +1,43 @@
+# 🚀 EKS Production Environment
+
+## 📋 Overview
+
+This directory contains a **reference skeleton** for deploying the MongoDB DBaaS Platform on AWS EKS. It demonstrates how the same Terraform modules used for local kind development can be reused for cloud production deployments.
+
+## 🏗️ Architecture
+
+```
+AWS Region (eu-west-1)
+├── VPC (10.0.0.0/16)
+│   ├── Private Subnets (3 AZs) - EKS worker nodes
+│   ├── Public Subnets (3 AZs) - Load balancers
+│   └── NAT Gateways
+├── EKS Cluster (v1.29)
+│   ├── Managed Node Group: m6i.xlarge x3-6
+│   ├── GP3 EBS volumes (100GB, 3000 IOPS)
+│   └── Encrypted storage
+├── Percona Operator (reuses modules/percona-operator)
+└── Observability Stack (reuses modules/observability)
+```
+
+## 🔧 Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- S3 bucket for Terraform state backend
+- DynamoDB table for state locking
+
+## 📖 Usage
+
+1. Uncomment the desired sections in `main.tf`
+2. Configure your AWS credentials and backend
+3. Run:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## 🔄 Module Reuse
+
+The same `modules/percona-operator` and `modules/observability` modules used in the `kind` environment are reused here, demonstrating the portability of the Terraform module structure across environments.

--- a/terraform/environments/eks/main.tf
+++ b/terraform/environments/eks/main.tf
@@ -1,0 +1,134 @@
+# ---------------------------------------------------------------------------
+# MongoDB DBaaS Platform - AWS EKS Production Environment
+# ---------------------------------------------------------------------------
+# This is a reference skeleton for deploying the platform on AWS EKS.
+# Uncomment and configure sections as needed for your AWS environment.
+# ---------------------------------------------------------------------------
+
+# terraform {
+#   required_version = ">= 1.5.0"
+#
+#   backend "s3" {
+#     bucket         = "mongodb-dbaas-tfstate"
+#     key            = "eks/terraform.tfstate"
+#     region         = "eu-west-1"
+#     dynamodb_table = "terraform-locks"
+#     encrypt        = true
+#   }
+#
+#   required_providers {
+#     aws = {
+#       source  = "hashicorp/aws"
+#       version = "~> 5.0"
+#     }
+#     kubernetes = {
+#       source  = "hashicorp/kubernetes"
+#       version = "~> 2.35"
+#     }
+#     helm = {
+#       source  = "hashicorp/helm"
+#       version = "~> 2.17"
+#     }
+#   }
+# }
+
+# ---------------------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------------------
+# module "vpc" {
+#   source  = "terraform-aws-modules/vpc/aws"
+#   version = "~> 5.0"
+#
+#   name = "mongodb-dbaas-vpc"
+#   cidr = "10.0.0.0/16"
+#
+#   azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+#   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+#   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+#
+#   enable_nat_gateway   = true
+#   single_nat_gateway   = false
+#   enable_dns_hostnames = true
+#
+#   tags = {
+#     Environment = "production"
+#     Project     = "mongodb-dbaas-platform"
+#     ManagedBy   = "terraform"
+#   }
+# }
+
+# ---------------------------------------------------------------------------
+# EKS Cluster
+# ---------------------------------------------------------------------------
+# module "eks" {
+#   source  = "terraform-aws-modules/eks/aws"
+#   version = "~> 20.0"
+#
+#   cluster_name    = "mongodb-dbaas"
+#   cluster_version = "1.29"
+#
+#   vpc_id     = module.vpc.vpc_id
+#   subnet_ids = module.vpc.private_subnets
+#
+#   cluster_endpoint_public_access = true
+#
+#   eks_managed_node_groups = {
+#     mongodb = {
+#       name           = "mongodb-workers"
+#       instance_types = ["m6i.xlarge"]
+#       min_size       = 3
+#       max_size       = 6
+#       desired_size   = 3
+#
+#       labels = {
+#         role    = "mongodb"
+#         project = "mongodb-dbaas-platform"
+#       }
+#
+#       # GP3 storage for MongoDB data
+#       block_device_mappings = {
+#         xvda = {
+#           device_name = "/dev/xvda"
+#           ebs = {
+#             volume_size = 100
+#             volume_type = "gp3"
+#             iops        = 3000
+#             throughput  = 125
+#             encrypted   = true
+#           }
+#         }
+#       }
+#     }
+#   }
+#
+#   tags = {
+#     Environment = "production"
+#     Project     = "mongodb-dbaas-platform"
+#     ManagedBy   = "terraform"
+#   }
+# }
+
+# ---------------------------------------------------------------------------
+# Percona Operator (reuses the same module as kind)
+# ---------------------------------------------------------------------------
+# module "percona_operator" {
+#   source = "../../modules/percona-operator"
+#
+#   namespace     = "mongodb-operator"
+#   chart_version = "1.22.0"
+#
+#   depends_on = [module.eks]
+# }
+
+# ---------------------------------------------------------------------------
+# Observability Stack (reuses the same module as kind)
+# ---------------------------------------------------------------------------
+# module "observability" {
+#   source = "../../modules/observability"
+#
+#   namespace              = "monitoring"
+#   prometheus_retention   = "15d"
+#   grafana_admin_password = var.grafana_admin_password
+#
+#   depends_on = [module.eks]
+# }

--- a/terraform/environments/kind/main.tf
+++ b/terraform/environments/kind/main.tf
@@ -1,0 +1,82 @@
+# ---------------------------------------------------------------------------
+# MongoDB DBaaS Platform - kind Development Environment
+# ---------------------------------------------------------------------------
+# Provisions a local kind cluster with Percona operator and optional
+# observability stack via Terraform.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Kind cluster
+# ---------------------------------------------------------------------------
+resource "kind_cluster" "dbaas" {
+  name            = var.cluster_name
+  node_image      = "kindest/node:${var.kubernetes_version}"
+  wait_for_ready  = true
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+      kubeadm_config_patches = [
+        <<-PATCH
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+        PATCH
+      ]
+    }
+
+    dynamic "node" {
+      for_each = range(var.worker_count)
+      content {
+        role = "worker"
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Kubernetes and Helm providers (configured after cluster creation)
+# ---------------------------------------------------------------------------
+provider "kubernetes" {
+  host                   = kind_cluster.dbaas.endpoint
+  cluster_ca_certificate = kind_cluster.dbaas.cluster_ca_certificate
+  client_certificate     = kind_cluster.dbaas.client_certificate
+  client_key             = kind_cluster.dbaas.client_key
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = kind_cluster.dbaas.endpoint
+    cluster_ca_certificate = kind_cluster.dbaas.cluster_ca_certificate
+    client_certificate     = kind_cluster.dbaas.client_certificate
+    client_key             = kind_cluster.dbaas.client_key
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Percona operator
+# ---------------------------------------------------------------------------
+module "percona_operator" {
+  source = "../../modules/percona-operator"
+
+  namespace     = var.operator_namespace
+  chart_version = var.operator_chart_version
+
+  depends_on = [kind_cluster.dbaas]
+}
+
+# ---------------------------------------------------------------------------
+# Observability stack (optional)
+# ---------------------------------------------------------------------------
+module "observability" {
+  source = "../../modules/observability"
+  count  = var.deploy_observability ? 1 : 0
+
+  namespace = var.monitoring_namespace
+
+  depends_on = [kind_cluster.dbaas]
+}

--- a/terraform/environments/kind/outputs.tf
+++ b/terraform/environments/kind/outputs.tf
@@ -1,0 +1,25 @@
+output "cluster_name" {
+  description = "Name of the kind cluster"
+  value       = kind_cluster.dbaas.name
+}
+
+output "kubeconfig" {
+  description = "Path to kubeconfig file"
+  value       = kind_cluster.dbaas.kubeconfig_path
+  sensitive   = true
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API server endpoint"
+  value       = kind_cluster.dbaas.endpoint
+}
+
+output "operator_namespace" {
+  description = "Namespace where Percona operator is deployed"
+  value       = module.percona_operator.namespace
+}
+
+output "monitoring_namespace" {
+  description = "Namespace where observability stack is deployed"
+  value       = var.deploy_observability ? module.observability[0].namespace : "N/A"
+}

--- a/terraform/environments/kind/terraform.tfvars.example
+++ b/terraform/environments/kind/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Example Terraform variables for kind development environment.
+# Copy to terraform.tfvars and adjust as needed.
+
+cluster_name       = "mongodb-dbaas"
+kubernetes_version = "v1.29.12"
+worker_count       = 3
+
+operator_namespace     = "mongodb-operator"
+operator_chart_version = "1.22.0"
+
+deploy_observability = true
+monitoring_namespace = "monitoring"

--- a/terraform/environments/kind/variables.tf
+++ b/terraform/environments/kind/variables.tf
@@ -1,0 +1,41 @@
+variable "cluster_name" {
+  description = "Name of the kind cluster"
+  type        = string
+  default     = "mongodb-dbaas"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for kind nodes"
+  type        = string
+  default     = "v1.29.12"
+}
+
+variable "worker_count" {
+  description = "Number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "operator_namespace" {
+  description = "Namespace for Percona operator"
+  type        = string
+  default     = "mongodb-operator"
+}
+
+variable "operator_chart_version" {
+  description = "Percona operator Helm chart version"
+  type        = string
+  default     = "1.22.0"
+}
+
+variable "deploy_observability" {
+  description = "Deploy kube-prometheus-stack"
+  type        = bool
+  default     = true
+}
+
+variable "monitoring_namespace" {
+  description = "Namespace for monitoring stack"
+  type        = string
+  default     = "monitoring"
+}

--- a/terraform/environments/kind/versions.tf
+++ b/terraform/environments/kind/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = "~> 0.7"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}

--- a/terraform/modules/observability/main.tf
+++ b/terraform/modules/observability/main.tf
@@ -1,0 +1,85 @@
+# ---------------------------------------------------------------------------
+# Observability Module
+# ---------------------------------------------------------------------------
+# Deploys kube-prometheus-stack via Helm for monitoring and dashboards.
+# ---------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/name"       = "observability"
+      "app.kubernetes.io/part-of"    = "mongodb-dbaas-platform"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "helm_release" "kube_prometheus_stack" {
+  name       = "kube-prometheus-stack"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+
+  values = [
+    yamlencode({
+      grafana = {
+        enabled       = true
+        adminUser     = var.grafana_admin_user
+        adminPassword = var.grafana_admin_password
+        service = {
+          type = "ClusterIP"
+          port = 3000
+        }
+        resources = {
+          requests = { cpu = "50m", memory = "128Mi" }
+          limits   = { memory = "256Mi" }
+        }
+        sidecar = {
+          dashboards = {
+            enabled        = true
+            label          = "grafana_dashboard"
+            labelValue     = "1"
+            searchNamespace = "ALL"
+          }
+        }
+      }
+      prometheus = {
+        prometheusSpec = {
+          retention       = var.prometheus_retention
+          scrapeInterval  = "30s"
+          resources = {
+            requests = { cpu = "100m", memory = "256Mi" }
+            limits   = { memory = "512Mi" }
+          }
+          serviceMonitorSelectorNilUsesHelmValues = false
+          podMonitorSelectorNilUsesHelmValues     = false
+          ruleSelectorNilUsesHelmValues            = false
+        }
+      }
+      alertmanager = {
+        enabled = true
+        alertmanagerSpec = {
+          resources = {
+            requests = { cpu = "10m", memory = "32Mi" }
+            limits   = { memory = "64Mi" }
+          }
+        }
+      }
+      nodeExporter = {
+        enabled = true
+      }
+      kubeStateMetrics = {
+        enabled = true
+      }
+      kubeProxy            = { enabled = false }
+      kubeScheduler        = { enabled = false }
+      kubeControllerManager = { enabled = false }
+      kubeEtcd             = { enabled = false }
+    })
+  ]
+
+  timeout = 300
+
+  depends_on = [kubernetes_namespace.monitoring]
+}

--- a/terraform/modules/observability/outputs.tf
+++ b/terraform/modules/observability/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace where the observability stack is deployed"
+  value       = kubernetes_namespace.monitoring.metadata[0].name
+}
+
+output "grafana_service" {
+  description = "Grafana service name for port-forwarding"
+  value       = "kube-prometheus-stack-grafana"
+}

--- a/terraform/modules/observability/variables.tf
+++ b/terraform/modules/observability/variables.tf
@@ -1,0 +1,24 @@
+variable "namespace" {
+  description = "Namespace for the monitoring stack"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "grafana_admin_user" {
+  description = "Grafana admin username"
+  type        = string
+  default     = "admin"
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password"
+  type        = string
+  default     = "admin"
+  sensitive   = true
+}
+
+variable "prometheus_retention" {
+  description = "Prometheus data retention period"
+  type        = string
+  default     = "2h"
+}

--- a/terraform/modules/percona-operator/main.tf
+++ b/terraform/modules/percona-operator/main.tf
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------
+# Percona Operator Module
+# ---------------------------------------------------------------------------
+# Deploys Percona Server for MongoDB Operator via Helm.
+# ---------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "operator" {
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/name"       = "percona-operator"
+      "app.kubernetes.io/part-of"    = "mongodb-dbaas-platform"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "helm_release" "operator_crds" {
+  name       = "psmdb-operator-crds"
+  repository = "https://percona.github.io/percona-helm-charts/"
+  chart      = "psmdb-operator-crds"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.operator.metadata[0].name
+
+  depends_on = [kubernetes_namespace.operator]
+}
+
+resource "helm_release" "operator" {
+  name       = "psmdb-operator"
+  repository = "https://percona.github.io/percona-helm-charts/"
+  chart      = "psmdb-operator"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.operator.metadata[0].name
+
+  values = [
+    yamlencode({
+      watchAllNamespaces = true
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "256Mi"
+        }
+        limits = {
+          memory = "512Mi"
+        }
+      }
+    })
+  ]
+
+  timeout = 120
+
+  depends_on = [helm_release.operator_crds]
+}

--- a/terraform/modules/percona-operator/outputs.tf
+++ b/terraform/modules/percona-operator/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace where the operator is deployed"
+  value       = kubernetes_namespace.operator.metadata[0].name
+}
+
+output "release_name" {
+  description = "Helm release name"
+  value       = helm_release.operator.name
+}

--- a/terraform/modules/percona-operator/variables.tf
+++ b/terraform/modules/percona-operator/variables.tf
@@ -1,0 +1,11 @@
+variable "namespace" {
+  description = "Namespace for the Percona operator"
+  type        = string
+  default     = "mongodb-operator"
+}
+
+variable "chart_version" {
+  description = "Helm chart version for Percona operator"
+  type        = string
+  default     = "1.22.0"
+}


### PR DESCRIPTION
## Summary
- 🏗️ Add Terraform `kind` environment with kind + Kubernetes + Helm providers
- 📦 Add reusable modules: `percona-operator` and `observability`
- ☁️ Add AWS EKS reference skeleton (commented, shows cloud readiness)
- 📖 Add `docs/guides/terraform-provisioning.md` usage guide
- 🔒 Add `terraform.tfvars` to `.gitignore`

## Test plan
- [ ] `terraform init` succeeds in `terraform/environments/kind/`
- [ ] `terraform plan` shows expected resources
- [ ] Module structure supports both kind and EKS environments

Closes #119, closes #120, closes #121, closes #122