### PR TITLE
feat(gitops): add ArgoCD with App of Apps and ApplicationSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,23 @@ deploy-backup: ## Configure PBM + MinIO + schedules
 		echo "Timeout waiting for MinIO pod."
 	@echo "Backup infrastructure deployed."
 
+.PHONY: deploy-argocd
+deploy-argocd: ## Deploy ArgoCD with App of Apps pattern
+	@echo "Deploying ArgoCD..."
+	@kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+	@helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true
+	@helm repo update argo
+	@helm upgrade --install argocd argo/argo-cd \
+		--namespace argocd \
+		-f gitops/argocd/values.yaml \
+		--wait --timeout 300s
+	@echo "ArgoCD installed. Deploying App of Apps..."
+	@kubectl apply -f gitops/argocd/apps/root-app.yaml
+	@kubectl apply -f gitops/argocd/appsets/tenant-claims.yaml
+	@echo "ArgoCD deployed with App of Apps pattern."
+	@echo "Access ArgoCD UI: kubectl port-forward svc/argocd-server 8080:80 -n argocd"
+	@echo "Credentials: admin / admin"
+
 # ──────────────────────────────────────────────
 # Data & utilities
 # ──────────────────────────────────────────────

--- a/docs/decisions/ADR-008-argocd-crossplane-complementary.md
+++ b/docs/decisions/ADR-008-argocd-crossplane-complementary.md
@@ -1,0 +1,69 @@
+# ADR-008: ArgoCD + Crossplane Complementary Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-003 selected Crossplane Compositions over ArgoCD ApplicationSets for the **self-service provisioning layer**. However, the platform still needs a GitOps delivery mechanism for managing platform components (operator, observability stack, cluster configurations).
+
+ArgoCD and Crossplane serve complementary roles:
+
+- **ArgoCD** excels at continuous delivery - syncing Kubernetes manifests from Git to clusters
+- **Crossplane** excels at infrastructure abstraction - exposing simplified APIs for complex resources
+
+## Decision
+
+Deploy ArgoCD alongside Crossplane with clear separation of concerns:
+
+| Layer | Tool | Responsibility |
+|-------|------|---------------|
+| Platform delivery | ArgoCD | Sync operator, observability, cluster configs from Git |
+| Self-service provisioning | Crossplane | Fulfill MongoDBInstance claims with XRD compositions |
+| Tenant onboarding | ArgoCD ApplicationSet | Auto-sync new tenant claims from Git to clusters |
+
+### Architecture
+
+```
+Git Repository
+  |
+  ├── ArgoCD App of Apps (root-app.yaml)
+  │   ├── percona-operator Application
+  │   ├── observability Application
+  │   └── mongodb-replicaset Application
+  |
+  └── ArgoCD ApplicationSet (tenant-claims)
+      └── Watches self-service/crossplane/examples/*-claim.yaml
+          └── Syncs Claims to cluster
+              └── Crossplane fulfills Claims -> PSMDB CRs
+```
+
+### Flow
+
+1. Platform team pushes manifest changes to Git
+2. ArgoCD detects drift and syncs to cluster (self-heal enabled)
+3. Product teams add claim files to `self-service/crossplane/examples/`
+4. ArgoCD ApplicationSet auto-creates an Application for each claim
+5. Crossplane Composition translates the claim into full PSMDB CR + namespace + NetworkPolicy
+
+## Consequences
+
+### Positive
+
+- Single source of truth in Git for all platform state
+- ArgoCD UI provides visual overview of all managed components
+- ApplicationSet bridges the gap between ArgoCD and Crossplane
+- No contradiction with ADR-003 - Crossplane still handles provisioning logic
+
+### Negative
+
+- Additional operational component (ArgoCD) to maintain
+- Resource overhead (~500 MB RAM for minimal ArgoCD deployment)
+- Requires careful RBAC separation between ArgoCD and Crossplane
+
+## References
+
+- ADR-003: Crossplane Compositions vs ArgoCD ApplicationSets
+- [ArgoCD App of Apps Pattern](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/)
+- [ApplicationSet Git Generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Git/)

--- a/gitops/argocd/apps/mongodb-replicaset.yaml
+++ b/gitops/argocd/apps/mongodb-replicaset.yaml
@@ -1,0 +1,29 @@
+---
+# MongoDB Replica Set Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mongodb-replicaset
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: mongodb-replicaset
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+    targetRevision: main
+    path: clusters/replicaset
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mongodb
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/argocd/apps/observability.yaml
+++ b/gitops/argocd/apps/observability.yaml
@@ -1,0 +1,29 @@
+---
+# Observability Stack Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: observability
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+    targetRevision: main
+    path: observability/grafana/configmaps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/argocd/apps/operator.yaml
+++ b/gitops/argocd/apps/operator.yaml
@@ -1,0 +1,29 @@
+---
+# Percona Operator Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: percona-operator
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: percona-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+    targetRevision: main
+    path: operator
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mongodb-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/gitops/argocd/apps/root-app.yaml
+++ b/gitops/argocd/apps/root-app.yaml
@@ -1,0 +1,34 @@
+---
+# Root Application - App of Apps pattern
+# This Application manages all platform component Applications.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mongodb-dbaas-platform
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: root-app
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+    targetRevision: main
+    path: gitops/argocd/apps
+    directory:
+      recurse: false
+      include: "*.yaml"
+      exclude: "root-app.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/gitops/argocd/appsets/tenant-claims.yaml
+++ b/gitops/argocd/appsets/tenant-claims.yaml
@@ -1,0 +1,47 @@
+---
+# ApplicationSet for tenant self-service claims.
+# Automatically creates ArgoCD Applications from Crossplane claim files.
+# ArgoCD syncs the Claims, Crossplane fulfills them.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenant-claims
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: tenant-claims
+    app.kubernetes.io/component: self-service
+    app.kubernetes.io/part-of: mongodb-dbaas-platform
+    app.kubernetes.io/managed-by: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+        revision: main
+        files:
+          - path: "self-service/crossplane/examples/*-claim.yaml"
+  template:
+    metadata:
+      name: "tenant-{{.path.basenameNormalized}}"
+      namespace: argocd
+      labels:
+        app.kubernetes.io/name: "tenant-{{.path.basenameNormalized}}"
+        app.kubernetes.io/component: tenant-database
+        app.kubernetes.io/part-of: mongodb-dbaas-platform
+        app.kubernetes.io/managed-by: argocd
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/Vedric/mongodb-k8s-dbaas-platform.git
+        targetRevision: main
+        path: "{{.path.path}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{.path.basenameNormalized}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/gitops/argocd/values.yaml
+++ b/gitops/argocd/values.yaml
@@ -1,0 +1,75 @@
+---
+# ArgoCD Helm values for kind development cluster.
+# Minimal resource footprint, single replica, no HA.
+
+# Global settings
+global:
+  image:
+    tag: "v2.14.11"
+
+# Server configuration
+server:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  service:
+    type: ClusterIP
+
+# Repo server
+repoServer:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+# Application controller
+controller:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+# Redis
+redis:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+
+# Disable Dex (SSO not needed for demos)
+dex:
+  enabled: false
+
+# Disable notifications (not needed for demos)
+notifications:
+  enabled: false
+
+# ApplicationSet controller
+applicationSet:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+
+# Configure initial admin password (bcrypt hash of "admin")
+configs:
+  params:
+    server.insecure: true
+  secret:
+    argocdServerAdminPassword: "$2a$10$rRyBsGSHK6.uc8fntPwVIuLVHgsAhAX7TcdrqW/RADU0uh7CaChLa"


### PR DESCRIPTION
## Summary
- 🔄 Add ArgoCD Helm values with minimal resources for kind
- 🌳 Add App of Apps pattern: root-app managing operator, observability, and replicaset
- 🏷️ Add ApplicationSet with Git generator for tenant self-service claims
- 🛠️ Add `make deploy-argocd` Makefile target
- 📝 Add ADR-008 documenting ArgoCD + Crossplane complementary pattern

## Test plan
- [ ] `make deploy-argocd` deploys ArgoCD + App of Apps
- [ ] ArgoCD UI accessible via port-forward on :8080 (admin/admin)
- [ ] App of Apps tree shows operator, observability, replicaset

Closes #123, closes #124, closes #125, closes #126